### PR TITLE
Fix PAT prompt validation and Azure DevOps URL encoding

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -2,6 +2,11 @@ import { createInterface } from 'node:readline';
 import type { AuthCredential } from '../types/work-item.js';
 import { getPat, storePat } from './credential-store.js';
 
+export function normalizePat(rawPat: string): string | null {
+  const trimmedPat = rawPat.trim();
+  return trimmedPat.length > 0 ? trimmedPat : null;
+}
+
 export async function promptForPat(): Promise<string | null> {
   if (!process.stdin.isTTY) {
     return null;
@@ -63,8 +68,11 @@ export async function resolvePat(): Promise<AuthCredential> {
 
   const promptedPat = await promptForPat();
   if (promptedPat !== null) {
-    await storePat(promptedPat);
-    return { pat: promptedPat, source: 'prompt' };
+    const normalizedPat = normalizePat(promptedPat);
+    if (normalizedPat !== null) {
+      await storePat(normalizedPat);
+      return { pat: normalizedPat, source: 'prompt' };
+    }
   }
 
   throw new Error(

--- a/src/services/azdo-client.ts
+++ b/src/services/azdo-client.ts
@@ -48,17 +48,20 @@ function buildExtraFields(
 }
 
 export async function getWorkItem(context: AzdoContext, id: number, pat: string, extraFields?: string[]): Promise<WorkItem> {
-  let url = `https://dev.azure.com/${context.org}/${context.project}/_apis/wit/workitems/${id}?api-version=7.1`;
+  const url = new URL(
+    `https://dev.azure.com/${encodeURIComponent(context.org)}/${encodeURIComponent(context.project)}/_apis/wit/workitems/${id}`,
+  );
+  url.searchParams.set('api-version', '7.1');
 
   if (extraFields && extraFields.length > 0) {
     const allFields = [...DEFAULT_FIELDS, ...extraFields];
-    url += `&fields=${allFields.join(',')}`;
+    url.searchParams.set('fields', allFields.join(','));
   }
   const token = Buffer.from(`:${pat}`).toString('base64');
 
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await fetch(url.toString(), {
       headers: {
         Authorization: `Basic ${token}`,
       },
@@ -121,12 +124,15 @@ export async function updateWorkItem(
   fieldName: string,
   operations: JsonPatchOperation[],
 ): Promise<UpdateResult> {
-  const url = `https://dev.azure.com/${context.org}/${context.project}/_apis/wit/workitems/${id}?api-version=7.1`;
+  const url = new URL(
+    `https://dev.azure.com/${encodeURIComponent(context.org)}/${encodeURIComponent(context.project)}/_apis/wit/workitems/${id}`,
+  );
+  url.searchParams.set('api-version', '7.1');
   const token = Buffer.from(`:${pat}`).toString('base64');
 
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await fetch(url.toString(), {
       method: 'PATCH',
       headers: {
         Authorization: `Basic ${token}`,

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getPatMock = vi.fn();
+const storePatMock = vi.fn();
+
+vi.mock('../../src/services/credential-store.js', () => ({
+  getPat: getPatMock,
+  storePat: storePatMock,
+}));
+
+describe('resolvePat', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.AZDO_PAT;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns env PAT before credential store', async () => {
+    process.env.AZDO_PAT = 'env-token';
+    getPatMock.mockResolvedValue('stored-token');
+
+    const auth = await import('../../src/services/auth.js');
+    const result = await auth.resolvePat();
+
+    expect(result).toEqual({ pat: 'env-token', source: 'env' });
+    expect(getPatMock).not.toHaveBeenCalled();
+    expect(storePatMock).not.toHaveBeenCalled();
+  });
+
+  it('does not store empty PAT entered at prompt', async () => {
+    getPatMock.mockResolvedValue(null);
+
+    const auth = await import('../../src/services/auth.js');
+    vi.spyOn(auth, 'promptForPat').mockResolvedValue('');
+
+    await expect(auth.resolvePat()).rejects.toThrow('Authentication cancelled');
+    expect(storePatMock).not.toHaveBeenCalled();
+  });
+
+});
+
+describe('normalizePat', () => {
+  it('returns null for blank input', async () => {
+    const auth = await import('../../src/services/auth.js');
+    expect(auth.normalizePat('   ')).toBeNull();
+  });
+
+  it('trims non-empty input', async () => {
+    const auth = await import('../../src/services/auth.js');
+    expect(auth.normalizePat('  prompt-token  ')).toBe('prompt-token');
+  });
+});

--- a/tests/unit/azdo-client.test.ts
+++ b/tests/unit/azdo-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getWorkItem } from '../../src/services/azdo-client.js';
+import { getWorkItem, updateWorkItem } from '../../src/services/azdo-client.js';
 import type { AzdoContext } from '../../src/types/work-item.js';
 
 const ctx: AzdoContext = { org: 'testorg', project: 'testproject' };
@@ -163,6 +163,57 @@ describe('getWorkItem', () => {
 
     expect(fetch).toHaveBeenCalledWith(
       'https://dev.azure.com/testorg/testproject/_apis/wit/workitems/99?api-version=7.1',
+      expect.any(Object),
+    );
+  });
+
+  it('URL-encodes organization and project in API URL', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeResponse({}));
+
+    await getWorkItem({ org: 'my org', project: 'My Project' }, 99, pat);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://dev.azure.com/my%20org/My%20Project/_apis/wit/workitems/99?api-version=7.1',
+      expect.any(Object),
+    );
+  });
+
+  it('URL-encodes fields query parameter', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeResponse({}));
+
+    await getWorkItem(ctx, 99, pat, ['Custom.Field Name']);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('fields='),
+      expect.any(Object),
+    );
+    const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('Custom.Field+Name');
+  });
+});
+
+describe('updateWorkItem', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('URL-encodes organization and project in update URL', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeResponse({}));
+
+    await updateWorkItem(
+      { org: 'my org', project: 'My Project' },
+      42,
+      pat,
+      'System.State',
+      [{ op: 'add', path: '/fields/System.State', value: 'Active' }],
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://dev.azure.com/my%20org/My%20Project/_apis/wit/workitems/42?api-version=7.1',
       expect.any(Object),
     );
   });


### PR DESCRIPTION
## Summary
- prevent empty PAT values from being accepted/stored when entered at prompt
- URL-encode organization, project, and query parameters when calling Azure DevOps Work Item APIs
- add regression tests for auth PAT normalization and encoded API URLs

## Validation
- npm run lint
- npm test