### PR TITLE
Fix field-value URL encoding and stabilize CLI tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "format": "prettier --check src/",
-    "test": "vitest run"
+    "test": "npm run build && vitest run"
   },
   "repository": {
     "type": "git",

--- a/src/services/azdo-client.ts
+++ b/src/services/azdo-client.ts
@@ -129,9 +129,13 @@ export async function getWorkItemFieldValue(
   pat: string,
   fieldName: string,
 ): Promise<string | null> {
-  const url = `https://dev.azure.com/${context.org}/${context.project}/_apis/wit/workitems/${id}?api-version=7.1&fields=${fieldName}`;
+  const url = new URL(
+    `https://dev.azure.com/${encodeURIComponent(context.org)}/${encodeURIComponent(context.project)}/_apis/wit/workitems/${id}`,
+  );
+  url.searchParams.set('api-version', '7.1');
+  url.searchParams.set('fields', fieldName);
 
-  const response = await fetchWithErrors(url, { headers: authHeaders(pat) });
+  const response = await fetchWithErrors(url.toString(), { headers: authHeaders(pat) });
 
   if (!response.ok) {
     throw new Error(`HTTP_${response.status}`);

--- a/tests/unit/azdo-client-field-value.test.ts
+++ b/tests/unit/azdo-client-field-value.test.ts
@@ -66,6 +66,22 @@ describe('getWorkItemFieldValue', () => {
     );
   });
 
+  it('URL-encodes org/project and field name in API URL', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeFieldResponse('Custom.Field Name', 'Test'),
+    );
+    await getWorkItemFieldValue(
+      { org: 'my org', project: 'my project' },
+      99,
+      pat,
+      'Custom.Field Name',
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      'https://dev.azure.com/my%20org/my%20project/_apis/wit/workitems/99?api-version=7.1&fields=Custom.Field+Name',
+      expect.any(Object),
+    );
+  });
+
   it('sends correct Authorization header', async () => {
     vi.mocked(fetch).mockResolvedValue(
       makeFieldResponse('System.Title', 'Test'),


### PR DESCRIPTION
## What this fixes
- Encode org/project/field query parameters in getWorkItemFieldValue to avoid malformed Azure DevOps API URLs for spaces/special characters.
- Make npm test build dist before running Vitest so tests/unit/cli.test.ts works on clean checkouts.
- Add regression coverage for encoded URL behavior in azdo-client-field-value tests.

## Changed files
- package.json
- src/services/azdo-client.ts
- tests/unit/azdo-client-field-value.test.ts

## Validation
I could not run lint/tests in this Codex sandbox because dependency installation is blocked by network resolution errors to registry.npmjs.org.
Please run locally:
- npm run lint
- npm test