### PR TITLE
docs(#41): sync authentication docs with current CLI auth surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Check [AGENTS.md](/workspaces/azdo-cli/AGENTS.md) for the real repository guidan
 Skills live in `.agents/skills`.
 
 ## Recent Changes
-- 020-auth-docs-sync: Added N/A for this change — documentation only (the project is TypeScript 5.x / Node.js LTS / commander.js). + None added. Verification uses the existing build (`tsup`) to run the CLI's `--help` output as ground truth.
+- 020-auth-docs-sync: Synced the authentication docs (`README.md`, `docs/commands.md`, `docs/linux-credential-store.md`) with the current `develop` auth surface — documented `azdo auth login` (OAuth default) alongside the PAT fallback. Documentation-only; no source or dependency changes (verified against the built CLI's `--help`).
 - 017-pr-comments-threads: Fixed `azdo pr comments` crash (tolerant `_links`, libuv-safe exit). Added `--pr-number <N>`, `--hide-resolved`, and `pr comment-resolve` / `pr comment-reopen` subcommands. No new runtime deps; kept the existing TypeScript 5.x / commander.js / native `fetch` stack.
 
 ## Active Technologies
-- N/A for this change — documentation only (the project is TypeScript 5.x / Node.js LTS / commander.js). + None added. Verification uses the existing build (`tsup`) to run the CLI's `--help` output as ground truth. (020-auth-docs-sync)
+- Documentation only — no new technologies; existing TypeScript 5.x / Node.js LTS / commander.js stack (020-auth-docs-sync)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,4 +5,8 @@ Check [AGENTS.md](/workspaces/azdo-cli/AGENTS.md) for the real repository guidan
 Skills live in `.agents/skills`.
 
 ## Recent Changes
+- 020-auth-docs-sync: Added N/A for this change — documentation only (the project is TypeScript 5.x / Node.js LTS / commander.js). + None added. Verification uses the existing build (`tsup`) to run the CLI's `--help` output as ground truth.
 - 017-pr-comments-threads: Fixed `azdo pr comments` crash (tolerant `_links`, libuv-safe exit). Added `--pr-number <N>`, `--hide-resolved`, and `pr comment-resolve` / `pr comment-reopen` subcommands. No new runtime deps; kept the existing TypeScript 5.x / commander.js / native `fetch` stack.
+
+## Active Technologies
+- N/A for this change — documentation only (the project is TypeScript 5.x / Node.js LTS / commander.js). + None added. Verification uses the existing build (`tsup`) to run the CLI's `--help` output as ground truth. (020-auth-docs-sync)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Azure DevOps CLI focused on work item read/write workflows.
 - Check branch pull request status, open PRs to `develop`, list PR comment threads for any PR (`--pr-number`), and resolve/reopen threads from the CLI (`pr`)
 - Persist org/project/default fields in local config (`config`)
 - List all fields of a work item (`list-fields`)
-- Store a PAT per Azure DevOps organization in the OS credential store via `azdo auth` (or use `AZDO_PAT`). Inspect with `azdo auth status`, remove with `azdo auth logout`. See [docs/authentication.md](docs/authentication.md).
+- Authenticate per Azure DevOps organization with `azdo auth login` — OAuth (Microsoft Entra) by default, or a Personal Access Token via `--use-pat` (or the `AZDO_PAT` env var). Credentials are stored in the OS credential store. Inspect with `azdo auth status`, remove with `azdo auth logout`. See [docs/authentication.md](docs/authentication.md).
 
 ## Installation
 
@@ -27,6 +27,9 @@ npm install -g azdo-cli
 ## Quick Start
 
 ```bash
+# Sign in to an organization (OAuth by default; add --use-pat for a PAT)
+azdo auth login --org myorg
+
 # Configure defaults once
 azdo config set org myorg
 azdo config set project myproject
@@ -56,7 +59,7 @@ azdo pr comment-reopen 17  --pr-number 64
 
 | Topic | File |
 |-------|------|
-| Authentication & PAT storage | [docs/authentication.md](docs/authentication.md) |
+| Authentication (OAuth & PAT) | [docs/authentication.md](docs/authentication.md) |
 | Linux credential store setup | [docs/linux-credential-store.md](docs/linux-credential-store.md) |
 | Full command reference | [docs/commands.md](docs/commands.md) |
 | Development setup | [docs/development.md](docs/development.md) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -66,7 +66,7 @@ cat description.md | azdo set-md-field 12345 System.Description
 ## Pull request commands
 
 The `pr` group uses the current git branch and the Azure DevOps `origin` remote automatically.
-Requires a PAT with **Code (Read)** scope for reads and **Code (Read & Write)** for creation.
+Requires a credential (OAuth or PAT) with **Code (Read)** scope for reads and **Code (Read & Write)** for creation.
 
 ```bash
 azdo pr status                             # list PRs for current branch + checks

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,9 +15,10 @@
 | `azdo list-fields <id>` | List all fields of a work item | `--json`, `--org`, `--project` |
 | `azdo pr <subcommand>` | Manage pull requests (current branch or by `--pr-number`) | `status`, `open`, `comments`, `comment-resolve`, `comment-reopen`, `--pr-number`, `--hide-resolved`, `--json`, `--org`, `--project` |
 | `azdo config <subcommand>` | Manage saved settings | `set`, `get`, `list`, `unset`, `wizard`, `--json` |
-| `azdo auth` | Store a PAT for an Azure DevOps organization in the OS secret vault | `--org`, `--from-stdin`, `--no-browser` |
-| `azdo auth status` | Report whether a PAT is stored for the resolved org (masked only) | `--org`, `--json` |
-| `azdo auth logout` | Remove the stored PAT for an org, or every org with `--all` | `--org`, `--all` |
+| `azdo auth login` | Authenticate against an org — OAuth (Microsoft Entra) by default, or a PAT with `--use-pat` | `--org`, `--use-pat`, `--device-code`, `--client-id`, `--tenant-id`, `--scopes`, `--from-stdin`, `--no-browser` |
+| `azdo auth` | Legacy PAT-prompt entry point (back-compat alias of `azdo auth login --use-pat`) | `--org`, `--from-stdin`, `--no-browser` |
+| `azdo auth status` | Report stored credentials (kind `pat`/`oauth`, org, account/expiry, backend) — never the token | `--org`, `--json` |
+| `azdo auth logout` | Remove the stored credential (PAT or OAuth) for an org, or every org with `--all` | `--org`, `--all` |
 | `azdo clear-pat` | **Deprecated** alias for `azdo auth logout` | `--org` |
 
 ---

--- a/docs/linux-credential-store.md
+++ b/docs/linux-credential-store.md
@@ -6,7 +6,7 @@ Without a working Secret Service backend credentials cannot be stored and you wi
 
 ## Desktop environments (GNOME, KDE, XFCE, etc.)
 
-Most modern Linux desktops already ship with GNOME Keyring or KWallet and start them automatically as part of the session. If `azdo store-pat` works without error you are done — no further setup needed.
+Most modern Linux desktops already ship with GNOME Keyring or KWallet and start them automatically as part of the session. If `azdo auth status` works without error you are done — no further setup needed.
 
 ## Headless / server / CI environments
 

--- a/docs/linux-credential-store.md
+++ b/docs/linux-credential-store.md
@@ -1,8 +1,8 @@
 # Linux Credential Store Setup
 
-`azdo-cli` uses [`@napi-rs/keyring`](https://github.com/napi-rs/keyring) to persist your PAT securely in the OS credential store. On Linux this library delegates to the **Secret Service API** (DBus), which is implemented by GNOME Keyring or KWallet.
+`azdo-cli` uses [`@napi-rs/keyring`](https://github.com/napi-rs/keyring) to persist your credentials (PAT or OAuth tokens) securely in the OS credential store. On Linux this library delegates to the **Secret Service API** (DBus), which is implemented by GNOME Keyring or KWallet.
 
-Without a working Secret Service backend the PAT cannot be stored and you will be prompted on every run (or you can use the `AZDO_PAT` environment variable instead).
+Without a working Secret Service backend credentials cannot be stored and you will be prompted on every run (or you can use the `AZDO_PAT` environment variable instead).
 
 ## Desktop environments (GNOME, KDE, XFCE, etc.)
 

--- a/specs/020-auth-docs-sync/checklists/requirements.md
+++ b/specs/020-auth-docs-sync/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Sync authentication docs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec is intentionally documentation-scoped (FR-008 / SC-005): no source behaviour changes.
+- Specific command/flag names appear in the Assumptions and Key Entities sections as ground truth derived from the current implementation; these describe *what the docs must match*, not implementation choices to be made.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`. All items pass.

--- a/specs/020-auth-docs-sync/contracts/auth-command-surface.md
+++ b/specs/020-auth-docs-sync/contracts/auth-command-surface.md
@@ -30,7 +30,7 @@ This is the canonical reference the documentation MUST match (FR-004). It is der
 - **Options**: `--org <name>`, `--all` (remove every stored credential).
 
 ### `azdo clear-pat` (deprecated)
-- **Description**: Deprecated alias of `azdo auth logout`. Prints a one-line deprecation notice and removes a stored PAT.
+- **Description**: Deprecated alias of `azdo auth logout`. Prints a one-line deprecation notice and removes the stored credential for the org — the per-org keyring slot is shared, so it clears whatever is stored (PAT or OAuth envelope), not only a PAT. (The command's own `--help` text still says "PAT" for historical reasons.)
 - **Options**: `--org <name>`.
 
 ## Environment variables (documented, behaviour unchanged)

--- a/specs/020-auth-docs-sync/contracts/auth-command-surface.md
+++ b/specs/020-auth-docs-sync/contracts/auth-command-surface.md
@@ -1,0 +1,45 @@
+# Contract: Authoritative auth command surface
+
+This is the canonical reference the documentation MUST match (FR-004). It is derived from `src/commands/auth.ts` on `develop` and verified via `node dist/index.js auth --help` (and subcommand `--help`). Any documentation statement about an auth command/flag must agree with this table.
+
+## Commands
+
+### `azdo auth login`
+- **Description**: Authenticate against Azure DevOps. **OAuth is the default**; `--use-pat` (or `--from-stdin`) selects the PAT path.
+- **Options** (`--org` declared on the subcommand; the rest are inherited from the parent `auth` via `optsWithGlobals()` and are valid on `login`):
+  - `--org <name>` — target organisation (else git remote → config)
+  - `--use-pat` — use a PAT instead of OAuth (legacy path)
+  - `--from-stdin` — read PAT from stdin (implies `--use-pat`)
+  - `--no-browser` — do not open the AzDO PAT page (PAT path only)
+  - `--device-code` — OAuth device-code flow (headless hosts)
+  - `--client-id <id>` — override default OAuth client id
+  - `--tenant-id <id>` — override default OAuth tenant id (default: `common`)
+  - `--scopes <scopes>` — space-separated OAuth scope override
+- **Mutual exclusion (exit code 2)**: `--use-pat` + `--device-code`; `--use-pat` + any of `--client-id` / `--tenant-id` / `--scopes`.
+
+### `azdo auth` (no subcommand)
+- **Description**: Legacy PAT-prompt entry point, kept for back-compat. Equivalent to the PAT path of `azdo auth login`.
+- **Options**: same option set as `login` (declared on the `auth` command); the root action runs the PAT-prompt flow.
+
+### `azdo auth status`
+- **Description**: Report stored credentials (kind `pat`/`oauth`, org, account/expiry for OAuth, keyring backend). **Never prints the token.**
+- **Options**: `--org <name>`, `--json`.
+
+### `azdo auth logout`
+- **Description**: Remove the stored credential for an org (PAT or OAuth).
+- **Options**: `--org <name>`, `--all` (remove every stored credential).
+
+### `azdo clear-pat` (deprecated)
+- **Description**: Deprecated alias of `azdo auth logout`. Prints a one-line deprecation notice and removes a stored PAT.
+- **Options**: `--org <name>`.
+
+## Environment variables (documented, behaviour unchanged)
+- `AZDO_PAT` — PAT taken from env, highest precedence over the vault.
+- `AZDO_OAUTH_CLIENT_ID` / `AZDO_OAUTH_TENANT_ID` — point OAuth at a self-registered app.
+
+## Doc-accuracy checklist (per FR-004 / SC-002)
+- [ ] Every command above appears in `docs/commands.md` with an accurate description.
+- [ ] `azdo auth login` is present and described as OAuth-default in `README.md` and `docs/commands.md`.
+- [ ] No doc references a command/flag absent from this contract.
+- [ ] `clear-pat` is marked deprecated wherever it appears.
+- [ ] Full `auth login` usage (flags) shown where flags are listed — not just `--org`.

--- a/specs/020-auth-docs-sync/data-model.md
+++ b/specs/020-auth-docs-sync/data-model.md
@@ -1,0 +1,38 @@
+# Data Model: Sync authentication docs
+
+This feature has no runtime data model. The relevant "entities" are the documentation artefacts and the command surface they must describe — captured here as a coverage matrix the implementation works against.
+
+## Entity: Authentication document
+
+| Attribute | Description |
+|---|---|
+| `path` | File path of the doc |
+| `role` | summary / command-reference / full-guide / registration-guide / setup-guide |
+| `status` | stale / accurate / verify-only |
+| `must-mention` | Commands/flows it must accurately describe |
+
+| path | role | status | must-mention |
+|---|---|---|---|
+| `README.md` | summary | stale | `azdo auth login` (OAuth default), PAT alternative, link to full guide |
+| `docs/commands.md` | command-reference | stale | `azdo auth login` row + accurate `auth`/`status`/`logout`/`clear-pat` rows |
+| `docs/authentication.md` | full-guide | accurate | (already complete — verify only) |
+| `docs/oauth-app-registration.md` | registration-guide | verify-only | custom Entra app, command names, cross-links |
+| `docs/linux-credential-store.md` | setup-guide | verify-only | no removed/renamed command references |
+
+## Entity: Auth command (target the docs must match)
+
+See [contracts/auth-command-surface.md](./contracts/auth-command-surface.md) for the authoritative definition. Summary:
+
+| command | kind | deprecated? |
+|---|---|---|
+| `azdo auth login` | OAuth (default) + PAT (`--use-pat`) | no |
+| `azdo auth` (bare) | legacy PAT-prompt alias | no (back-compat) |
+| `azdo auth status` | inspect | no |
+| `azdo auth logout` | remove | no |
+| `azdo clear-pat` | remove (PAT) | **yes** → use `auth logout` |
+
+## Relationship / consistency rules
+
+- Every command in the second table MUST be represented accurately in the `must-mention` of the relevant doc(s) (FR-003/FR-004).
+- The same command/flow described in more than one doc MUST be described consistently (FR-005) — same command names, same default (OAuth), same deprecation status.
+- Internal cross-links between these docs MUST resolve (FR-009 / SC-004).

--- a/specs/020-auth-docs-sync/plan.md
+++ b/specs/020-auth-docs-sync/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Sync authentication docs
+
+**Branch**: `020-auth-docs-sync` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/020-auth-docs-sync/spec.md`
+
+## Summary
+
+Bring the authentication documentation into line with the actual auth command surface implemented on `develop`. The reported problem (#41) is that the entry-point docs (`README.md`, `docs/commands.md`) predate the OAuth work (#37/#38) and only describe the PAT path, making `azdo auth login` look unsupported. Per the owner's **Option A** decision, the docs are synced to the current `develop` surface as-is (no per-release version caveat). `docs/authentication.md` is already accurate and is the source of truth; the work is correcting the stale summaries and verifying every documented command/flag against the built CLI. **Documentation only — no source changes.**
+
+## Technical Context
+
+**Language/Version**: N/A for this change — documentation only (the project is TypeScript 5.x / Node.js LTS / commander.js).  
+**Primary Dependencies**: None added. Verification uses the existing build (`tsup`) to run the CLI's `--help` output as ground truth.  
+**Storage**: N/A  
+**Testing**: No automated tests added. Verification is manual/visual: build the CLI and diff documented commands/flags against `--help`; check internal links resolve. Existing `npm run lint && npm test && npm run build` must still pass (they don't cover Markdown, but must not regress).  
+**Target Platform**: N/A (docs render on GitHub / npm readme).  
+**Project Type**: Single-project CLI; docs live in `README.md` and `docs/`.  
+**Performance Goals**: N/A  
+**Constraints**: Docs-only diff (SC-005). No new CLI flags or behaviour. Cross-links must resolve (SC-004).  
+**Scale/Scope**: 2 primary stale files (`README.md`, `docs/commands.md`) + verification pass over `docs/authentication.md`, `docs/oauth-app-registration.md`, and any other auth-referencing doc.
+
+### Ground-truth auth command surface (verified on `develop`)
+
+Captured from `node dist/index.js auth --help` and reading `src/commands/auth.ts`:
+
+| Command | Purpose | Options |
+|---|---|---|
+| `azdo auth login` | Authenticate (OAuth default; `--use-pat` for PAT) | `--org`, plus inherited: `--use-pat`, `--from-stdin`, `--no-browser`, `--device-code`, `--client-id <id>`, `--tenant-id <id>`, `--scopes <s>` |
+| `azdo auth` (bare) | Legacy PAT-prompt entry point (back-compat alias) | same option set as above; root action runs the PAT path |
+| `azdo auth status` | Report stored credentials (kind/org/account/expiry/backend), never the token | `--org`, `--json` |
+| `azdo auth logout` | Remove stored credential for an org | `--org`, `--all` |
+| `azdo clear-pat` | **Deprecated** — removes a stored PAT; use `azdo auth logout` | `--org` |
+
+**Subtlety the docs must respect:** the OAuth flags are declared on the parent `auth` command and inherited by `login` via `optsWithGlobals()`. So `azdo auth login --device-code` (etc.) works even though `azdo auth login --help` lists only `--org`. Docs should show the full `auth login` usage (as `docs/authentication.md` already does) and not be misled by the terse `login --help`.
+
+**Release state:** the `login` command (commit `ff80f2c`, #37/PR #38) is on `develop` only; no released tag contains it (latest `0.10.1`). Per Option A, docs describe `develop` without a version caveat.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The constitution's code principles (I CLI-First, II TypeScript Strictness, III Single-Responsibility, IV npm Distribution, V Simplicity) are **not engaged** — this change touches no source, commands, build, or dependencies.
+
+The directly relevant clause is **Development Workflow**: *"After every completed SpecKit spec run, README.md MUST be reviewed and updated to reflect the implemented functionality, commands, options, and usage examples before merge."* This feature **is** that README/doc reconciliation — it satisfies the clause rather than violating it.
+
+**Result: PASS, no violations.** Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/020-auth-docs-sync/
+├── plan.md              # This file
+├── research.md          # Phase 0 — ground-truth surface + stale-spot inventory
+├── data-model.md        # Phase 1 — doc-set ↔ command-surface coverage matrix
+├── quickstart.md        # Phase 1 — how to verify the docs match the CLI
+├── contracts/
+│   └── auth-command-surface.md   # Authoritative command/flag table docs must match
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+No source code is modified. The artifacts edited by this feature are documentation files:
+
+```text
+README.md                        # authentication summary (stale → add auth login / OAuth)
+docs/
+├── commands.md                  # command reference (stale → add auth login row, fix auth/status/logout)
+├── authentication.md            # full guide (already accurate — verify, adjust only on drift)
+├── oauth-app-registration.md    # custom Entra app registration (verify cross-links/commands)
+└── linux-credential-store.md    # verify only — touch only if it names a removed/renamed command
+```
+
+**Structure Decision**: Documentation-only change. Primary edits: `README.md` and `docs/commands.md`. Verification-and-touch-on-drift: `docs/authentication.md`, `docs/oauth-app-registration.md`, and any other auth-referencing doc surfaced by a repo-wide grep.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/020-auth-docs-sync/pr-report.md
+++ b/specs/020-auth-docs-sync/pr-report.md
@@ -1,0 +1,25 @@
+# PR Report: Sync authentication docs
+
+**Branch**: `020-auth-docs-sync`
+**Date**: 2026-05-29
+**Spec**: [specs/020-auth-docs-sync/spec.md](spec.md)
+
+## Summary
+
+The authentication documentation had drifted from the CLI: the entry-point docs (`README.md`, `docs/commands.md`) predated the OAuth work (#37/#38) and only described the PAT path, making `azdo auth login` look unsupported (issue #41). This PR reconciles the auth docs with the actual `develop` command surface — documenting `azdo auth login` (OAuth default) alongside the PAT alternative — and verifies every documented command/flag against the built CLI. Documentation only; no source or behaviour changes.
+
+## What's New
+
+<!-- finalised in step 11 -->
+
+- [Filled in once /speckit-implement completes]
+
+## Testing
+
+<!-- finalised in step 11 -->
+
+- **Manual**: [Filled in once /speckit-implement completes — quickstart verification: build CLI, diff docs against `--help`, link check]
+
+## Notes
+
+- Per the owner's **Option A** decision: `azdo auth login` is documented as current even though it is unreleased (on `develop`, no tag yet — latest release `0.10.1` predates it). No per-release version caveat. Cutting a release is out of scope for this issue.

--- a/specs/020-auth-docs-sync/pr-report.md
+++ b/specs/020-auth-docs-sync/pr-report.md
@@ -10,15 +10,16 @@ The authentication documentation had drifted from the CLI: the entry-point docs 
 
 ## What's New
 
-<!-- finalised in step 11 -->
-
-- [Filled in once /speckit-implement completes]
+- **README authentication summary**: now presents `azdo auth login` (OAuth via Microsoft Entra, default) with PAT as the `--use-pat` alternative, instead of the old PAT-only `azdo auth` description. Added a sign-in line to Quick Start and relabelled the docs table row to "Authentication (OAuth & PAT)".
+- **Command reference (`docs/commands.md`)**: added the missing `azdo auth login` row (with its full option set), reframed bare `azdo auth` as the legacy PAT-prompt alias, and updated `auth status` / `auth logout` descriptions to cover both OAuth and PAT (not PAT-only). `clear-pat` remains marked deprecated. The PR-command scope note now says "credential (OAuth or PAT)" rather than "PAT".
+- **Linux credential store doc**: generalised "PAT" wording to "credentials (PAT or OAuth tokens)" for consistency.
+- **Verified (no change needed)**: `docs/authentication.md` and `docs/oauth-app-registration.md` already matched the implemented surface; all internal cross-links across the touched docs resolve.
+- **Encoded gotcha**: docs show the full `azdo auth login` usage (OAuth flags are inherited from the parent `auth` via `optsWithGlobals()`, so `auth login --help` looks bare but the flags work).
 
 ## Testing
 
-<!-- finalised in step 11 -->
-
-- **Manual**: [Filled in once /speckit-implement completes — quickstart verification: build CLI, diff docs against `--help`, link check]
+- **Manual / quickstart verification**: built the CLI and diffed documented commands/flags against `auth --help`, `auth login/status/logout --help`, and `clear-pat --help`; confirmed the entry-point docs now show `auth login`; ran a repo-wide grep finding no remaining PAT-only stale phrasing; verified all internal cross-links resolve.
+- **Repo checks (must-not-regress)**: `npm run lint` ✓, `npm run build` ✓, unit tests **546 passed**, integration tests **90 passed / 7 skipped** (pre-existing env-gated skips). No source files changed, so behaviour is unaffected.
 
 ## Notes
 

--- a/specs/020-auth-docs-sync/quickstart.md
+++ b/specs/020-auth-docs-sync/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: Verifying the auth docs match the CLI
+
+This feature is documentation-only; "validation" means confirming the docs match the actual CLI and that links resolve. Steps an implementer/reviewer runs:
+
+## 1. Build the current CLI (source of truth)
+
+```bash
+npm run build
+node dist/index.js auth --help
+node dist/index.js auth login --help
+node dist/index.js auth status --help
+node dist/index.js auth logout --help
+node dist/index.js clear-pat --help
+```
+
+Compare the output against [contracts/auth-command-surface.md](./contracts/auth-command-surface.md). Remember: `auth login --help` lists only `--org`; the OAuth flags are inherited from the parent `auth` and still valid on `login`.
+
+## 2. Confirm the entry-point docs now show login/OAuth
+
+```bash
+grep -n "auth login" README.md docs/commands.md
+```
+
+Expected: `README.md` mentions `azdo auth login` (OAuth default) and `docs/commands.md` has an `azdo auth login` row.
+
+## 3. Find any remaining stale references
+
+```bash
+grep -rniE 'azdo auth|clear-pat|AZDO_PAT|personal access token' README.md docs/
+```
+
+Every hit must describe a command/flag that exists in the contract; no doc may claim login is unsupported or describe `azdo auth` as PAT-only without acknowledging OAuth.
+
+## 4. Check internal links resolve
+
+For each Markdown link target referenced in the touched docs, confirm the file/anchor exists (e.g. `docs/authentication.md`, `docs/oauth-app-registration.md`, `docs/linux-credential-store.md`).
+
+## 5. Confirm no source changed
+
+```bash
+git diff --name-only develop... | grep -vE '^(README\.md|docs/|specs/)' || echo "OK: docs/specs only"
+```
+
+Expected: only `README.md`, files under `docs/`, and the spec bundle under `specs/` are touched (SC-005).
+
+## 6. Repo checks must not regress
+
+```bash
+npm run lint && npm test && npm run build
+```
+
+(These do not cover Markdown but must remain green.)

--- a/specs/020-auth-docs-sync/research.md
+++ b/specs/020-auth-docs-sync/research.md
@@ -1,0 +1,45 @@
+# Research: Sync authentication docs
+
+Phase 0 establishes the ground truth (the actual auth command surface) and inventories the stale spots. There were no open `NEEDS CLARIFICATION` items after the spec's Option A decision; the "research" here is empirical verification against the running CLI and the docs.
+
+## Decision 1 — Source of truth for the auth surface
+
+- **Decision**: Use the built CLI's `--help` output on `develop` (and `src/commands/auth.ts`) as the authoritative description; treat `docs/authentication.md` as the already-accurate prose source of truth.
+- **Rationale**: The issue stems from docs drifting from code. The only reliable reference is what the code does. `docs/authentication.md` was verified to match the CLI, so it anchors the reconciliation.
+- **Alternatives considered**: Trusting the existing README/commands.md (rejected — they're the stale artefacts); inferring from changelog/PRs (rejected — less reliable than the binary).
+
+### Verified surface (build + `--help` + source)
+
+- `azdo auth login` — OAuth default; `--use-pat`/`--from-stdin` switch to the PAT path. Inherited flags from parent `auth`: `--org`, `--use-pat`, `--from-stdin`, `--no-browser`, `--device-code`, `--client-id <id>`, `--tenant-id <id>`, `--scopes <s>`.
+- `azdo auth` (bare) — legacy PAT-prompt alias (`handleAuthRoot` → `handlePatLogin`).
+- `azdo auth status` — `--org`, `--json`; reports kind/org/account/expiry/backend, never the token.
+- `azdo auth logout` — `--org`, `--all`.
+- `azdo clear-pat` — deprecated alias of `auth logout` (`--org`).
+- Mutual-exclusion rules exist (e.g. `--use-pat` + `--device-code` → exit 2), already documented in `docs/authentication.md`.
+
+## Decision 2 — Release-state handling (Option A)
+
+- **Decision**: Document the `develop` surface as current, with **no per-release version caveat**.
+- **Rationale**: Owner chose Option A. `login` (#37, commit `ff80f2c`) is merged to `develop` but in no released tag (latest `0.10.1`); the owner's PAT-only `auth` help came from the released binary. Docs on `develop` describe `develop`; the command ships to users at the next release (out of scope here).
+- **Alternatives considered**: Option B (mark login as "from next release") and Option C (cut a release first) — both declined by the owner.
+
+## Decision 3 — Documentation gotcha to encode
+
+- **Decision**: Docs must show the full `azdo auth login` usage (with OAuth flags), not the terse `auth login --help`.
+- **Rationale**: The OAuth flags live on the parent `auth` command and are inherited by `login` via `optsWithGlobals()`. `azdo auth login --help` therefore lists only `--org`, but `azdo auth login --device-code` etc. work. A naive doc author reading only `login --help` would wrongly omit the flags. `docs/authentication.md` already gets this right.
+
+## Stale-spot inventory (to fix / verify)
+
+| File | Status | Action |
+|---|---|---|
+| `README.md` (auth summary, ~line 19) | **Stale** — only "Store a PAT … via `azdo auth`"; no `login`/OAuth | Add `azdo auth login` (OAuth default) + PAT alternative; keep link to `docs/authentication.md` |
+| `docs/commands.md` (auth rows, ~18–21) | **Stale** — `azdo auth` = "Store a PAT", **no `auth login` row**, stale flags | Add `azdo auth login` row; update `auth`/`status`/`logout` descriptions to reflect OAuth+PAT; keep `clear-pat` deprecated |
+| `docs/authentication.md` | **Accurate** | Verify against surface; adjust only on genuine drift |
+| `docs/oauth-app-registration.md` | Likely accurate | Verify command names + cross-links resolve |
+| `docs/linux-credential-store.md` | Secret-service setup, not commands | Verify only; touch only if it names a removed/renamed command |
+| Repo-wide grep for `azdo auth`/`clear-pat`/`AZDO_PAT` | TBD in implement | Catch any other stale reference |
+
+## Open risks
+
+- A grep may surface stale auth references outside the known files (e.g. other docs, code comments). Code comments are out of scope (docs-only); other docs get the same accurate description.
+- `docs/authentication.md` mentions a "default `client_id` for the project's shared OAuth application" that must be registered — this is a maintainer note, accurate, left as-is.

--- a/specs/020-auth-docs-sync/spec.md
+++ b/specs/020-auth-docs-sync/spec.md
@@ -84,6 +84,12 @@ A user who follows any authentication-related document finds the commands, flags
 - **SC-004**: All internal cross-links within the touched authentication docs resolve to an existing file/anchor (zero broken links introduced).
 - **SC-005**: No source files (CLI commands, flags, behaviour) are modified — the diff is limited to documentation.
 
+## Clarifications
+
+### Session 2026-05-29
+
+- Q: `azdo auth login` is implemented on `develop` (added by #37, commit `ff80f2c`) but is **not yet in any released tag** (latest release `0.10.1` predates it; the released binary's `azdo auth` has only `status`/`logout`). How should the docs treat this unreleased command? → A: **Option A** — sync the docs to the current `develop` auth surface as-is (document `azdo auth login`/OAuth as current), with **no per-release version caveat**. Login reaches users when the next release is cut; cutting that release is out of scope for this docs issue. [owner: alkampfergit, 2026-05-29]
+
 ## Assumptions
 
 - "The document" in the issue refers to the authentication documentation set as a whole, not a single file; the entry-point docs (README, command reference) are the primary stale artefacts, with `docs/authentication.md` already largely accurate.

--- a/specs/020-auth-docs-sync/spec.md
+++ b/specs/020-auth-docs-sync/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Sync authentication docs
+
+**Feature Branch**: `020-auth-docs-sync`  
+**Created**: 2026-05-29  
+**Status**: Draft  
+**Input**: User description: "Reconcile the Azure DevOps CLI authentication documentation with the current CLI auth surface (issue #41). The reporter believes `azdo auth login` is no longer supported and that other parts of the document are outdated. Owner clarification: `azdo auth login` IS still supported, via a custom Azure AD application (the OAuth flow introduced in #37/#38). Update the documentation so it accurately reflects the current authentication commands and flows. Documentation only — no source code behaviour changes."
+
+## Context
+
+Issue #41 reports that the authentication documentation is out of sync with the tool. Investigation shows the situation is mixed:
+
+- `docs/authentication.md` is **already current** — it documents OAuth as the default, `azdo auth login`, the device-code flow, `--use-pat`, the legacy bare `azdo auth` alias, `azdo auth logout`, `azdo auth status`, and the deprecated `azdo clear-pat`.
+- The **entry-point docs predate the OAuth work** (#37/#38) and only describe the PAT path:
+  - `README.md` describes storing a PAT via `azdo auth` and never mentions `azdo auth login` or OAuth.
+  - `docs/commands.md` lists `azdo auth` as "Store a PAT", omits the `azdo auth login` command entirely, and lists a stale flag set.
+
+A reader who starts from the README or the command reference therefore concludes that login/OAuth is unsupported — exactly the confusion the issue describes. The owner has confirmed `azdo auth login` is supported and works against a custom Azure DevOps (Microsoft Entra) application.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A new user can discover and use the supported login command (Priority: P1)
+
+A person evaluating `azdo-cli` reads the top-level README and the command reference to learn how to authenticate. The documentation correctly tells them that `azdo auth login` is the supported, default (OAuth) way to sign in, alongside the PAT option, so they can authenticate successfully on their first attempt without believing the command was removed.
+
+**Why this priority**: This is the exact failure reported in #41 — the entry-point docs make a supported command look unsupported. Fixing it resolves the reported problem and is the minimum viable outcome.
+
+**Independent Test**: Read `README.md` and `docs/commands.md` end to end as a new user; confirm `azdo auth login` (and OAuth being the default) is presented as a current, supported command and that the steps match the tool's actual behaviour.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader on the README, **When** they look for how to sign in, **Then** they find `azdo auth login` presented as the default OAuth sign-in, with PAT described as the alternative, and a link to the full authentication guide.
+2. **Given** a reader on the command reference (`docs/commands.md`), **When** they scan the command table, **Then** `azdo auth login` is listed with an accurate description and its relevant options, and the existing `azdo auth` / `auth status` / `auth logout` / `clear-pat` rows accurately describe today's behaviour (OAuth + PAT, not PAT-only).
+
+---
+
+### User Story 2 - Every authentication doc is consistent with the implemented commands (Priority: P2)
+
+A user who follows any authentication-related document finds the commands, flags, and flows described there match what the CLI actually does, with no contradictions between documents.
+
+**Why this priority**: The issue says "other parts of the document are outdated too." Beyond the headline login command, cross-document consistency (terminology, command names, deprecations, the OAuth-via-custom-Entra-app flow) prevents the next reader from hitting a different stale statement.
+
+**Independent Test**: Cross-check every command, flag, and flow mentioned in the auth docs against the actual CLI command surface; confirm there are no references to removed/renamed commands and no contradictions between documents.
+
+**Acceptance Scenarios**:
+
+1. **Given** the set of authentication-related docs, **When** each documented command and flag is compared against the actual CLI surface, **Then** every documented command and flag exists and behaves as described, and no removed/renamed command is presented as current.
+2. **Given** the OAuth-via-custom-Azure-AD-application flow, **When** a reader follows the registration and login guidance, **Then** the documents agree on the command names, the role of a custom Entra application, and the relevant environment variables / flags, with consistent cross-links between them.
+
+---
+
+### Edge Cases
+
+- A command or flag is mentioned in one doc but missing or differently named in another → the docs must be reconciled to a single accurate description.
+- The full guide (`docs/authentication.md`) is already accurate while the summaries are stale → summaries are corrected to point at and agree with the guide; the guide is left correct (only adjusted if a genuine drift from the implementation is found).
+- A documented command was genuinely removed/renamed in the current code → it is updated or removed, not left as if current (verification must surface this rather than assume the docs are right).
+- Deprecated-but-present commands (e.g. `azdo clear-pat`) → documented as deprecated with the recommended replacement, not deleted.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The documentation MUST present `azdo auth login` as a currently supported command, with OAuth (against a Microsoft Entra / Azure AD application) as the default sign-in method and PAT as the supported alternative.
+- **FR-002**: The top-level `README.md` authentication summary MUST mention `azdo auth login` and the OAuth default (not only the PAT path) and link to the full authentication guide.
+- **FR-003**: The command reference (`docs/commands.md`) MUST include `azdo auth login` with an accurate description and its relevant options, and MUST update the existing `azdo auth`, `azdo auth status`, and `azdo auth logout` entries so their descriptions reflect both OAuth and PAT rather than PAT-only.
+- **FR-004**: Every authentication command and flag described in any authentication-related document MUST correspond to a command/flag that actually exists in the current CLI; references to removed or renamed commands MUST be corrected or removed.
+- **FR-005**: The documents MUST be mutually consistent — the same command, flow, and terminology described one way in one document MUST NOT be described contradictorily in another.
+- **FR-006**: The OAuth-via-custom-Azure-AD-application flow MUST be documented coherently across the relevant docs (what the custom application is for, how login uses it, and the relevant flags/environment variables), with working cross-links.
+- **FR-007**: Deprecated-but-still-present commands MUST be labelled as deprecated with their recommended replacement, rather than removed or presented as primary.
+- **FR-008**: The change MUST be documentation-only — no source code, command behaviour, or CLI flags are altered as part of this work.
+- **FR-009**: Any internal documentation cross-links touched MUST resolve to existing files/anchors.
+
+### Key Entities
+
+- **Authentication documents**: the set of docs describing how to authenticate — at minimum `README.md` (summary), `docs/commands.md` (command reference), `docs/authentication.md` (full guide), and `docs/oauth-app-registration.md` (custom Entra app registration). These are the artefacts brought into a consistent, accurate state.
+- **Authentication command surface**: the actual set of CLI auth commands and flags the docs must match — `azdo auth login` (with OAuth default, `--device-code`, `--use-pat`, and related flags), bare `azdo auth` (legacy PAT-prompt alias), `azdo auth status`, `azdo auth logout`, and the deprecated `azdo clear-pat`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reader starting from the README can identify the supported sign-in command (`azdo auth login`, OAuth default) without consulting source code — the previously reported "login is not supported" conclusion is no longer reachable from the entry-point docs.
+- **SC-002**: 100% of authentication commands and flags referenced across the documentation correspond to commands/flags that exist in the current CLI (zero references to removed/renamed commands).
+- **SC-003**: There are zero contradictions between authentication documents for any command, flag, or flow that appears in more than one of them.
+- **SC-004**: All internal cross-links within the touched authentication docs resolve to an existing file/anchor (zero broken links introduced).
+- **SC-005**: No source files (CLI commands, flags, behaviour) are modified — the diff is limited to documentation.
+
+## Assumptions
+
+- "The document" in the issue refers to the authentication documentation set as a whole, not a single file; the entry-point docs (README, command reference) are the primary stale artefacts, with `docs/authentication.md` already largely accurate.
+- `docs/authentication.md` is treated as the most current source of truth and is adjusted only where a genuine drift from the actual implementation is found during verification.
+- The current implemented auth surface (per the source) is: `azdo auth login` (OAuth default; `--device-code`, `--use-pat`, `--client-id`, `--tenant-id`, `--scopes`, `--from-stdin`, `--no-browser`), bare `azdo auth` (legacy PAT-prompt back-compat alias), `azdo auth status`, `azdo auth logout` (`--all`), and the deprecated `azdo clear-pat`.
+- No new documentation pages are required; the work is correcting and reconciling existing ones (adding a missing command row/section is in scope, but creating new guides is not).

--- a/specs/020-auth-docs-sync/tasks.md
+++ b/specs/020-auth-docs-sync/tasks.md
@@ -22,7 +22,7 @@ description: "Task list for 020-auth-docs-sync"
 
 **Purpose**: Establish the ground-truth auth surface the docs must match.
 
-- [ ] T001 Build the current CLI and capture authoritative help: run `npm run build` then `node dist/index.js auth --help`, `node dist/index.js auth login --help`, `auth status --help`, `auth logout --help`, `clear-pat --help`; keep the output as the reference.
+- [X] T001 Build the current CLI and capture authoritative help: run `npm run build` then `node dist/index.js auth --help`, `node dist/index.js auth login --help`, `auth status --help`, `auth logout --help`, `clear-pat --help`; keep the output as the reference.
 
 ---
 
@@ -32,7 +32,7 @@ description: "Task list for 020-auth-docs-sync"
 
 **⚠️ CRITICAL**: No doc edits begin until the contract is confirmed accurate.
 
-- [ ] T002 Verify `specs/020-auth-docs-sync/contracts/auth-command-surface.md` against the T001 output and `src/commands/auth.ts`; correct the contract if any command/flag/deprecation differs (this contract is the reference for all later tasks).
+- [X] T002 Verify `specs/020-auth-docs-sync/contracts/auth-command-surface.md` against the T001 output and `src/commands/auth.ts`; correct the contract if any command/flag/deprecation differs (this contract is the reference for all later tasks).
 
 **Checkpoint**: Authoritative surface confirmed — doc edits can begin.
 
@@ -46,8 +46,8 @@ description: "Task list for 020-auth-docs-sync"
 
 ### Implementation for User Story 1
 
-- [ ] T003 [P] [US1] Update the authentication summary in `README.md` (~line 19 and the "Authentication & PAT storage" reference at ~line 59): present `azdo auth login` as the default (OAuth) sign-in, PAT as the supported alternative, keep/repair the link to `docs/authentication.md`. Match the contract; do not over-describe (summary, not full guide).
-- [ ] T004 [P] [US1] Update the auth rows in `docs/commands.md` (~lines 18–21): add an `azdo auth login` row (OAuth default; key options `--use-pat`, `--device-code`, `--org`); revise the `azdo auth`, `azdo auth status`, `azdo auth logout` descriptions to reflect OAuth + PAT (not PAT-only); keep `azdo clear-pat` marked **Deprecated** with `azdo auth logout` as the replacement. Flags/descriptions must match `contracts/auth-command-surface.md`.
+- [X] T003 [P] [US1] Update the authentication summary in `README.md` (~line 19 and the "Authentication & PAT storage" reference at ~line 59): present `azdo auth login` as the default (OAuth) sign-in, PAT as the supported alternative, keep/repair the link to `docs/authentication.md`. Match the contract; do not over-describe (summary, not full guide).
+- [X] T004 [P] [US1] Update the auth rows in `docs/commands.md` (~lines 18–21): add an `azdo auth login` row (OAuth default; key options `--use-pat`, `--device-code`, `--org`); revise the `azdo auth`, `azdo auth status`, `azdo auth logout` descriptions to reflect OAuth + PAT (not PAT-only); keep `azdo clear-pat` marked **Deprecated** with `azdo auth logout` as the replacement. Flags/descriptions must match `contracts/auth-command-surface.md`.
 
 **Checkpoint**: Entry-point docs no longer make `azdo auth login` look unsupported (SC-001). MVP complete.
 
@@ -61,10 +61,10 @@ description: "Task list for 020-auth-docs-sync"
 
 ### Implementation for User Story 2
 
-- [ ] T005 [P] [US2] Verify `docs/authentication.md` against `contracts/auth-command-surface.md`; it is expected to be accurate — edit only where a genuine drift from the CLI is found. Confirm the full `azdo auth login` usage (with OAuth flags) is shown (per the `optsWithGlobals()` gotcha in research.md).
-- [ ] T006 [P] [US2] Verify `docs/oauth-app-registration.md`: command names match the contract, the custom-Entra-app flow is described coherently, and all internal cross-links resolve.
-- [ ] T007 [US2] Repo-wide sweep for stale auth references: `grep -rniE 'azdo auth|clear-pat|AZDO_PAT|personal access token' README.md docs/`. For every hit in a doc, confirm it matches the contract and is consistent with the other docs; fix any stale/contradictory statement. (Code/comment hits are out of scope — docs only.)
-- [ ] T008 [US2] Verify all internal cross-links in the touched docs resolve to an existing file/anchor (`README.md`, `docs/commands.md`, `docs/authentication.md`, `docs/oauth-app-registration.md`, `docs/linux-credential-store.md`) — zero broken links (SC-004).
+- [X] T005 [P] [US2] Verify `docs/authentication.md` against `contracts/auth-command-surface.md`; it is expected to be accurate — edit only where a genuine drift from the CLI is found. Confirm the full `azdo auth login` usage (with OAuth flags) is shown (per the `optsWithGlobals()` gotcha in research.md).
+- [X] T006 [P] [US2] Verify `docs/oauth-app-registration.md`: command names match the contract, the custom-Entra-app flow is described coherently, and all internal cross-links resolve.
+- [X] T007 [US2] Repo-wide sweep for stale auth references: `grep -rniE 'azdo auth|clear-pat|AZDO_PAT|personal access token' README.md docs/`. For every hit in a doc, confirm it matches the contract and is consistent with the other docs; fix any stale/contradictory statement. (Code/comment hits are out of scope — docs only.)
+- [X] T008 [US2] Verify all internal cross-links in the touched docs resolve to an existing file/anchor (`README.md`, `docs/commands.md`, `docs/authentication.md`, `docs/oauth-app-registration.md`, `docs/linux-credential-store.md`) — zero broken links (SC-004).
 
 **Checkpoint**: All auth docs accurate and mutually consistent (SC-002, SC-003).
 

--- a/specs/020-auth-docs-sync/tasks.md
+++ b/specs/020-auth-docs-sync/tasks.md
@@ -1,0 +1,139 @@
+---
+description: "Task list for 020-auth-docs-sync"
+---
+
+# Tasks: Sync authentication docs
+
+**Input**: Design documents from `/specs/020-auth-docs-sync/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/auth-command-surface.md, quickstart.md
+
+**Tests**: Not applicable — this is a documentation-only change. "Validation" is the manual verification in `quickstart.md` (build the CLI, diff docs against `--help`, check links). No automated test tasks are generated.
+
+**Organization**: Tasks grouped by user story. US1 (P1) fixes the reported failure (entry-point docs); US2 (P2) reconciles/verifies the rest of the auth doc set.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the ground-truth auth surface the docs must match.
+
+- [ ] T001 Build the current CLI and capture authoritative help: run `npm run build` then `node dist/index.js auth --help`, `node dist/index.js auth login --help`, `auth status --help`, `auth logout --help`, `clear-pat --help`; keep the output as the reference.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Confirm the command-surface contract is correct before editing any prose.
+
+**⚠️ CRITICAL**: No doc edits begin until the contract is confirmed accurate.
+
+- [ ] T002 Verify `specs/020-auth-docs-sync/contracts/auth-command-surface.md` against the T001 output and `src/commands/auth.ts`; correct the contract if any command/flag/deprecation differs (this contract is the reference for all later tasks).
+
+**Checkpoint**: Authoritative surface confirmed — doc edits can begin.
+
+---
+
+## Phase 3: User Story 1 - New user can discover and use the login command (Priority: P1) 🎯 MVP
+
+**Goal**: A reader of the entry-point docs (`README.md`, `docs/commands.md`) can see `azdo auth login` (OAuth default) presented as a current, supported command — resolving the #41 confusion.
+
+**Independent Test**: Read `README.md` and `docs/commands.md` as a new user; confirm `azdo auth login` and the OAuth default are present and accurate, with PAT as the alternative and a link to the full guide.
+
+### Implementation for User Story 1
+
+- [ ] T003 [P] [US1] Update the authentication summary in `README.md` (~line 19 and the "Authentication & PAT storage" reference at ~line 59): present `azdo auth login` as the default (OAuth) sign-in, PAT as the supported alternative, keep/repair the link to `docs/authentication.md`. Match the contract; do not over-describe (summary, not full guide).
+- [ ] T004 [P] [US1] Update the auth rows in `docs/commands.md` (~lines 18–21): add an `azdo auth login` row (OAuth default; key options `--use-pat`, `--device-code`, `--org`); revise the `azdo auth`, `azdo auth status`, `azdo auth logout` descriptions to reflect OAuth + PAT (not PAT-only); keep `azdo clear-pat` marked **Deprecated** with `azdo auth logout` as the replacement. Flags/descriptions must match `contracts/auth-command-surface.md`.
+
+**Checkpoint**: Entry-point docs no longer make `azdo auth login` look unsupported (SC-001). MVP complete.
+
+---
+
+## Phase 4: User Story 2 - All auth docs consistent with the implemented commands (Priority: P2)
+
+**Goal**: Every authentication-related document matches the actual CLI and is mutually consistent — no stale/contradictory references, no broken links.
+
+**Independent Test**: Cross-check every command/flag/flow in the auth docs against the contract; confirm zero references to removed/renamed commands and zero contradictions between docs.
+
+### Implementation for User Story 2
+
+- [ ] T005 [P] [US2] Verify `docs/authentication.md` against `contracts/auth-command-surface.md`; it is expected to be accurate — edit only where a genuine drift from the CLI is found. Confirm the full `azdo auth login` usage (with OAuth flags) is shown (per the `optsWithGlobals()` gotcha in research.md).
+- [ ] T006 [P] [US2] Verify `docs/oauth-app-registration.md`: command names match the contract, the custom-Entra-app flow is described coherently, and all internal cross-links resolve.
+- [ ] T007 [US2] Repo-wide sweep for stale auth references: `grep -rniE 'azdo auth|clear-pat|AZDO_PAT|personal access token' README.md docs/`. For every hit in a doc, confirm it matches the contract and is consistent with the other docs; fix any stale/contradictory statement. (Code/comment hits are out of scope — docs only.)
+- [ ] T008 [US2] Verify all internal cross-links in the touched docs resolve to an existing file/anchor (`README.md`, `docs/commands.md`, `docs/authentication.md`, `docs/oauth-app-registration.md`, `docs/linux-credential-store.md`) — zero broken links (SC-004).
+
+**Checkpoint**: All auth docs accurate and mutually consistent (SC-002, SC-003).
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and guardrails.
+
+- [ ] T009 Run the `quickstart.md` verification end-to-end (steps 1–6) and confirm each expectation holds.
+- [ ] T010 Confirm the change is documentation-only: `git diff --name-only develop...` shows only `README.md`, `docs/**`, and `specs/**` (SC-005); no source/CLI files changed.
+- [ ] T011 Confirm repo checks still pass: `npm run lint && npm test && npm run build` (must not regress).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1, T001)**: no dependencies — start immediately.
+- **Foundational (Phase 2, T002)**: depends on T001 — BLOCKS all doc edits.
+- **US1 (Phase 3)**: depends on T002. Delivers the MVP (fixes #41).
+- **US2 (Phase 4)**: depends on T002. Independent of US1 (different files) but logically follows for full consistency.
+- **Polish (Phase 5)**: depends on US1 + US2.
+
+### User Story Dependencies
+
+- **US1 (P1)**: after T002 — independently testable via the README/commands.md read.
+- **US2 (P2)**: after T002 — independently testable via the cross-doc consistency check. No hard dependency on US1.
+
+### Parallel Opportunities
+
+- US1: T003 (`README.md`) and T004 (`docs/commands.md`) are different files → run in parallel.
+- US2: T005 and T006 are different files → run in parallel; T007/T008 follow once edits settle.
+- US1 and US2 touch disjoint files and can proceed in parallel after T002.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# After T002, launch both entry-point edits together:
+Task T003: Update authentication summary in README.md
+Task T004: Update auth rows in docs/commands.md
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. T001 (Setup) → T002 (confirm contract).
+2. T003 + T004 (US1) → entry-point docs fixed.
+3. **STOP and VALIDATE**: read README + commands.md; `azdo auth login` is present and accurate → #41's core complaint resolved.
+
+### Incremental Delivery
+
+1. Setup + Foundational → ground truth confirmed.
+2. US1 → entry-point docs (MVP, fixes #41).
+3. US2 → full auth-doc consistency + link check.
+4. Polish → quickstart verification, docs-only diff check, repo checks green.
+
+---
+
+## Notes
+
+- [P] = different files, no dependency on an incomplete task.
+- The command-surface contract (`contracts/auth-command-surface.md`) is the single reference for every doc edit — when in doubt, the built CLI's `--help` wins.
+- Documentation-only: no source, no CLI flags, no behaviour changes (FR-008 / SC-005).
+- Commit after each logical group (e.g. US1 edits, then US2).
+- Per the constitution, `README.md` accuracy after the spec run is a hard requirement — T003 covers it.

--- a/specs/020-auth-docs-sync/tasks.md
+++ b/specs/020-auth-docs-sync/tasks.md
@@ -74,9 +74,9 @@ description: "Task list for 020-auth-docs-sync"
 
 **Purpose**: Final validation and guardrails.
 
-- [ ] T009 Run the `quickstart.md` verification end-to-end (steps 1–6) and confirm each expectation holds.
-- [ ] T010 Confirm the change is documentation-only: `git diff --name-only develop...` shows only `README.md`, `docs/**`, and `specs/**` (SC-005); no source/CLI files changed.
-- [ ] T011 Confirm repo checks still pass: `npm run lint && npm test && npm run build` (must not regress).
+- [X] T009 Run the `quickstart.md` verification end-to-end (steps 1–6) and confirm each expectation holds.
+- [X] T010 Confirm the change is documentation-only: `git diff --name-only develop...` shows only `README.md`, `docs/**`, and `specs/**` (SC-005); no source/CLI files changed.
+- [X] T011 Confirm repo checks still pass: `npm run lint && npm test && npm run build` (must not regress).
 
 ---
 


### PR DESCRIPTION
## Summary

The authentication documentation had drifted from the CLI: the entry-point docs (`README.md`, `docs/commands.md`) predated the OAuth work (#37/#38) and only described the PAT path, making `azdo auth login` look unsupported (issue #41). This PR reconciles the auth docs with the actual `develop` command surface — documenting `azdo auth login` (OAuth default) alongside the PAT alternative — and verifies every documented command/flag against the built CLI. **Documentation only; no source or behaviour changes.**

Closes #41

## What's New

- **README authentication summary**: now presents `azdo auth login` (OAuth via Microsoft Entra, default) with PAT as the `--use-pat` alternative, instead of the old PAT-only `azdo auth` description. Added a sign-in line to Quick Start and relabelled the docs-table row to "Authentication (OAuth & PAT)".
- **Command reference (`docs/commands.md`)**: added the missing `azdo auth login` row (full option set), reframed bare `azdo auth` as the legacy PAT-prompt alias, and updated `auth status` / `auth logout` descriptions to cover both OAuth and PAT. `clear-pat` stays marked deprecated. PR-command scope note now reads "credential (OAuth or PAT)".
- **Linux credential store doc**: generalised "PAT" wording to "credentials (PAT or OAuth tokens)".
- **Verified (no change needed)**: `docs/authentication.md` and `docs/oauth-app-registration.md` already matched the implemented surface; all internal cross-links resolve.
- **Gotcha encoded**: docs show the full `azdo auth login` usage (OAuth flags are inherited from the parent `auth` via `optsWithGlobals()`, so `auth login --help` looks bare but the flags work).

## Decision (Option A)

`azdo auth login` is documented as current even though it is unreleased (on `develop`; latest release `0.10.1` predates #37). No per-release version caveat — per owner decision on #41. Cutting a release is out of scope for this issue.

## Approved artefacts

- Spec: specs/020-auth-docs-sync/spec.md
- Plan: specs/020-auth-docs-sync/plan.md
- Tasks: specs/020-auth-docs-sync/tasks.md
- Command-surface contract: specs/020-auth-docs-sync/contracts/auth-command-surface.md
- PR report: specs/020-auth-docs-sync/pr-report.md

## Test plan

- [x] Built the CLI and diffed documented commands/flags against `auth --help` / `auth login|status|logout --help` / `clear-pat --help`.
- [x] Confirmed entry-point docs (`README.md`, `docs/commands.md`) now show `azdo auth login`.
- [x] Repo-wide grep — no remaining PAT-only stale phrasing.
- [x] All internal cross-links resolve.
- [x] Docs-only diff (no `src/`, `tests/`, or build files changed).
- [x] `npm run lint` ✓, `npm run build` ✓, unit **546 passed**, integration **90 passed / 7 skipped**.
