### PR TITLE
feat(#47): check for newer stable version on startup

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -217,6 +217,25 @@ azdo config unset fields
 azdo config list --json
 ```
 
+## Update notifications
+
+On each command run `azdo` quietly checks the npm registry for a newer **stable**
+release and, if one is found, prints a single line to **stderr** after the
+command's own output:
+
+```
+A new version of azdo-cli is available: 0.5.0 → 0.6.0. Run `npm i -g azdo-cli` to update.
+```
+
+The check is best-effort and never blocks or fails your command:
+
+- **Throttled** to at most one registry lookup per 10 minutes (a failed check
+  does not reset the window, so the next run may retry).
+- **Suppressed** when output is non-interactive (piped, redirected, or in CI),
+  so it never pollutes stdout/JSON.
+- **Opt-out** with the global `--no-update-check` flag, e.g.
+  `azdo --no-update-check get-item 1234`.
+
 ## JSON output
 
 All commands that produce structured data support `--json`:

--- a/specs/022-version-update-check/checklists/requirements.md
+++ b/specs/022-version-update-check/checklists/requirements.md
@@ -13,7 +13,7 @@
 
 ## Requirement Completeness
 
-- [ ] No [NEEDS CLARIFICATION] markers remain
+- [x] No [NEEDS CLARIFICATION] markers remain
 - [x] Requirements are testable and unambiguous
 - [x] Success criteria are measurable
 - [x] Success criteria are technology-agnostic (no implementation details)
@@ -31,5 +31,5 @@
 
 ## Notes
 
-- Four `[NEEDS CLARIFICATION]` markers remain by design — they are genuine, scope/UX-impacting decisions deferred to `/speckit-clarify` (per the speckit-gh flow): failed-check throttle behaviour, CI/non-interactive suppression, notice frequency within a window, and the opt-out mechanism.
-- All other quality items pass.
+- All four `[NEEDS CLARIFICATION]` markers were resolved by the owner (alkampfergit) on 2026-06-01 and encoded in the spec's Clarifications section: failed checks do not reset the throttle; the notice is suppressed in non-interactive contexts; the notice is single-line and shown once per 10-min window; opt-out via `--no-update-check`.
+- All quality items pass.

--- a/specs/022-version-update-check/checklists/requirements.md
+++ b/specs/022-version-update-check/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Check for new stable version on startup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Four `[NEEDS CLARIFICATION]` markers remain by design — they are genuine, scope/UX-impacting decisions deferred to `/speckit-clarify` (per the speckit-gh flow): failed-check throttle behaviour, CI/non-interactive suppression, notice frequency within a window, and the opt-out mechanism.
+- All other quality items pass.

--- a/specs/022-version-update-check/contracts/update-check.md
+++ b/specs/022-version-update-check/contracts/update-check.md
@@ -1,0 +1,58 @@
+# Contract: update-check service
+
+**Feature**: 022-version-update-check | **Module**: `src/services/update-check.ts`
+
+This is a CLI-internal module contract (no HTTP contract is exposed by this tool; the only outbound call is to the public npm registry).
+
+## Public surface
+
+```ts
+export interface UpdateCheckDeps {
+  now?: () => number;                         // default: Date.now
+  readCache?: () => string | null;            // default: read ~/.azdo/update-check.json
+  writeCache?: (data: string) => void;        // default: write ~/.azdo/update-check.json
+  fetchLatest?: () => Promise<string | null>; // default: fetch registry latest, return version or null
+  isTTY?: () => boolean;                       // default: () => Boolean(process.stderr.isTTY)
+  currentVersion?: string;                    // default: version from src/version.ts
+}
+
+/**
+ * Best-effort update check. Resolves to a one-line notice string when a fresh,
+ * successful check finds a newer stable version, otherwise null. NEVER throws,
+ * NEVER blocks beyond the bounded fetch, NEVER writes to stdout/stderr itself.
+ */
+export function getUpdateNotice(opts?: { enabled?: boolean } & UpdateCheckDeps): Promise<string | null>;
+
+/** Helper: numeric semver "is `latest` strictly newer than `current`?" (pre-release < release). */
+export function isNewer(latest: string, current: string): boolean;
+```
+
+Dependency injection (clock, fs, fetch, TTY, version) exists purely so unit tests run with no real I/O.
+
+## Behavioural contract
+
+| # | Given | When | Then |
+| --- | --- | --- | --- |
+| C1 | `enabled === false` (`--no-update-check`) | `getUpdateNotice` called | returns `null`; no cache read, no fetch |
+| C2 | `isTTY()` is false | called | returns `null`; no fetch |
+| C3 | cache `lastCheck` within `THROTTLE_MS` of `now()` | called | returns `null`; **no fetch** (cached window) |
+| C4 | throttle elapsed; `fetchLatest()` returns version **newer** than current | called | writes cache `{lastCheck: now, latestVersion}`; returns the one-line notice |
+| C5 | throttle elapsed; `fetchLatest()` returns version **≤** current | called | writes cache; returns `null` |
+| C6 | throttle elapsed; `fetchLatest()` throws / returns null (network fail or timeout) | called | **cache unchanged**; returns `null` |
+| C7 | cache file missing / corrupt / wrong shape | called | treated as `lastCheck=0`; proceeds to fetch; never throws |
+| C8 | current version unparseable or ≥ latest (dev/local build) | called | returns `null` (no misleading notice) |
+
+## Caller contract (`src/index.ts`)
+
+- Register a global `--no-update-check` option (commander `--no-x` → `opts().updateCheck` defaults `true`).
+- Switch `program.parse()` → `await program.parseAsync()`.
+- After the command runs (commander `postAction` hook, or after `parseAsync` resolves), call `getUpdateNotice({ enabled: program.opts().updateCheck })` and, if it returns a string, `process.stderr.write(notice + "\n")`.
+- Skip the call for `-v/--version` and help paths.
+- The notice must print **after** the command's own output and must not change the process exit code.
+
+## Non-functional guarantees
+
+- No throw escapes `getUpdateNotice`.
+- At most one registry request per `THROTTLE_MS` window.
+- No writes to stdout; notice text is returned, the caller writes it to stderr.
+- No new runtime dependency.

--- a/specs/022-version-update-check/data-model.md
+++ b/specs/022-version-update-check/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: Check for new stable version on startup
+
+**Feature**: 022-version-update-check | **Date**: 2026-06-01
+
+This feature has a single persisted entity (a small local cache) and a couple of transient value objects. No Azure DevOps or network entity is persisted.
+
+## Entity: UpdateCheckCache (persisted)
+
+Stored at `~/.azdo/update-check.json`.
+
+| Field | Type | Description | Notes |
+| --- | --- | --- | --- |
+| `lastCheck` | number (epoch ms) | Timestamp of the last **successful** registry check | Only updated on success; drives the 10-min throttle |
+| `latestVersion` | string (semver) | Latest stable version seen at `lastCheck` | e.g. `"0.6.0"` |
+
+**Validation / tolerance**:
+- File missing, empty, non-JSON, or failing the type guard → treated as "no recent check" (proceed as if `lastCheck = 0`); never throws (FR-008).
+- Type guard requires `lastCheck` to be a finite number and `latestVersion` a non-empty string; otherwise discard.
+
+**Lifecycle**:
+- Read at the start of every (non-suppressed) check.
+- Rewritten only after a successful registry fetch.
+- A failed fetch leaves it unchanged (clarification 1).
+- Safe to delete at any time (pure cache).
+
+## Value object: RunningVersion (transient)
+
+- Source: `version` exported from `src/version.ts` (i.e. `package.json` version).
+- Used as the left operand of the "is newer" comparison.
+
+## Value object: UpdateNotice (transient)
+
+Produced only when a fresh successful check finds a newer stable version.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `currentVersion` | string | The running version |
+| `latestVersion` | string | The newer stable version |
+
+Rendered as a single stderr line, e.g.:
+
+```
+A new version of azdo-cli is available: 0.5.0 → 0.6.0. Run `npm i -g azdo-cli` to update.
+```
+
+## Derived constants
+
+| Constant | Value | Meaning |
+| --- | --- | --- |
+| `THROTTLE_MS` | `10 * 60 * 1000` | 10-minute throttle window |
+| `FETCH_TIMEOUT_MS` | `1500` | Abort timeout for the registry request |
+| `REGISTRY_URL` | `https://registry.npmjs.org/azdo-cli/latest` | Latest-stable endpoint |

--- a/specs/022-version-update-check/plan.md
+++ b/specs/022-version-update-check/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: Check for new stable version on startup
+
+**Branch**: `022-version-update-check` | **Date**: 2026-06-01 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/022-version-update-check/spec.md`
+
+## Summary
+
+Add a lightweight, throttled, non-blocking npm update check to the `azdo` CLI. On command execution the tool reads a small cache file; if the last *successful* check is older than 10 minutes it performs one quick request to the npm registry for the latest **stable** version of `azdo-cli`, and — if that is newer than the running version — prints a single-line upgrade notice to stderr after the command's own output. The check never blocks or errors the user's command, is suppressed in non-interactive output, and can be disabled with `--no-update-check`.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode) on Node.js LTS (18+)
+**Primary Dependencies**: commander.js (existing), native `fetch` (built-in), `node:fs` / `node:path` / `node:os` (built-in) — **no new runtime dependency**
+**Storage**: JSON cache file at `~/.azdo/update-check.json` (reuses the existing `~/.azdo/` directory used by `config-store.ts`)
+**Testing**: vitest (`npm test` builds then runs unit + integration)
+**Target Platform**: cross-platform CLI (Linux/macOS/Windows)
+**Project Type**: single-project CLI
+**Performance Goals**: cached path (the common case) does zero network I/O and only one small synchronous file read (negligible); a fresh registry check happens at most once per 10 minutes and is bounded by a short abort timeout
+**Constraints**: must never block/slow the invoked command, never surface an error from the check, suppress in non-interactive output, throttle to ≤1 registry lookup / 10 min
+**Scale/Scope**: one new service module + one global option + entrypoint wiring + tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. CLI-First Design** ✅ — exposes a global `--no-update-check` option; notice goes to **stderr** so stdout/JSON output is untouched; never changes exit codes.
+- **II. TypeScript Strictness** ✅ — strict types, no `any`; cache parsing uses `unknown` + a type guard.
+- **III. Single Responsibility** ✅ — all logic lives in a new `src/services/update-check.ts`; the entrypoint only wires it.
+- **IV. npm Distribution** ✅ — no new runtime dependency; native `fetch` + built-ins only; nothing added to the bundle beyond the new module.
+- **Testing** ✅ — unit tests for throttle/compare/suppression logic with injected clock, fs, fetch, and TTY; no real network in unit tests.
+
+No violations → Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-version-update-check/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── update-check.md  # Phase 1 output — module contract
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── index.ts                      # MODIFIED: register --no-update-check; run notice after the command
+├── services/
+│   ├── config-store.ts           # (existing) — source of the ~/.azdo dir convention
+│   └── update-check.ts           # NEW: cache I/O, throttle, registry fetch, version compare, notice
+└── version.ts                    # (existing) — running version
+
+tests/
+└── unit/
+    └── update-check.test.ts      # NEW: throttle, compare, suppression, failure-safety
+```
+
+**Structure Decision**: Single-project CLI (matches the repo). One new service module holds all behaviour; `src/index.ts` is the only existing file modified. The cache lives under `~/.azdo/` (the directory already created/used by `config-store.ts`), keeping all CLI state in one place.
+
+## Key design decisions (detail in research.md)
+
+1. **Registry query**: `GET https://registry.npmjs.org/azdo-cli/latest` — the `latest` dist-tag is the stable release by definition (excludes pre-releases), and the per-version endpoint returns a small manifest (fastest option). Parse `.version`. Native `fetch` with an `AbortController` timeout (~1500 ms).
+2. **Throttle & failure semantics**: read `~/.azdo/update-check.json`; if `lastCheck` is < 10 min ago, do nothing (no network). Only a **successful** fetch rewrites `lastCheck` — a failed/timed-out check leaves the file unchanged so the next invocation may retry (per clarification 1).
+3. **Notice cadence**: the single-line notice is emitted **only on the invocation that performs a fresh successful check** and finds a newer stable version. Cached-window invocations print nothing → "once per 10-minute window" with no per-command spam (clarification 3).
+4. **Non-blocking**: the check is gated on the throttle first (so the overwhelmingly common path is one sync file read). When a check is due it runs via a `postAction` hook (switching `program.parse()` → `await program.parseAsync()`), bounded by the abort timeout, and prints **after** the command output.
+5. **Suppression**: skip entirely when `--no-update-check` is set (clarification 4) or when stderr is non-interactive (`!process.stderr.isTTY`) (clarification 2). Also skip for `-v/--version` and `help`.
+6. **Safety**: every step is wrapped so any error (network, parse, fs) is swallowed — the user's command and exit code are never affected (FR-007/FR-008). Dev/local builds (running version ≥ latest) produce no notice (FR-010).
+
+## Complexity Tracking
+
+*No constitution violations — not applicable.*

--- a/specs/022-version-update-check/pr-report.md
+++ b/specs/022-version-update-check/pr-report.md
@@ -14,12 +14,42 @@ non-interactive output, and can be disabled with `--no-update-check`.
 
 ## What's New
 
-<!-- finalised in step 11 -->
-
-- **[placeholder]**
+- **Update-check service (`src/services/update-check.ts`)**: a new self-contained
+  module that reads a small `~/.azdo/update-check.json` cache, throttles registry
+  lookups to at most one per 10 minutes, fetches the `latest` stable version from
+  `registry.npmjs.org` under a 1500 ms abort timeout, compares it numerically
+  against the running version, and returns a one-line notice only when a fresh,
+  successful check finds something newer. Every step is wrapped so it can never
+  throw or block the user's command.
+- **CLI wiring (`src/index.ts`)**: a global `--no-update-check` flag, the entry
+  point switched to `parseAsync()`, and a `postAction` hook that writes the
+  notice to **stderr after** the command's own output. The hook does not fire for
+  `-v/--version` or help, so those paths stay silent.
+- **Failure & suppression semantics**: the notice is suppressed when output is
+  non-interactive (`!process.stderr.isTTY`) or when `--no-update-check` is set; a
+  failed/timed-out check leaves the cache unchanged so the throttle window is not
+  reset; a corrupt or missing cache is tolerated as "no recent check".
+- **Docs (`docs/commands.md`)**: a new "Update notifications" section describing
+  the behaviour, the 10-minute throttle, the `--no-update-check` opt-out, and the
+  non-interactive suppression.
 
 ## Testing
 
-<!-- finalised in step 11 -->
+- **Unit (`tests/unit/update-check.test.ts`, 21 cases)**: cover contract cases
+  C1–C8 — suppression (disabled / non-TTY), throttle (within / elapsed window),
+  failure safety (fetch returns null or throws → cache untouched), tolerant cache
+  parsing (corrupt / missing / wrong-shape), and `isNewer` semantics (newer /
+  equal / older / pre-release precedence / `v` prefix / build metadata /
+  unparseable). All dependencies (clock, fs, fetch, TTY, version) are injected so
+  no test performs real I/O.
+- **Full suite**: `npm run lint`, `npm run typecheck`, `npm run build`, and
+  `npm test` (757 passed, 7 skipped, 0 failed) all green.
+- **Manual smoke**: `azdo --help` lists `--no-update-check`; `azdo
+  --no-update-check config list` runs without crashing and emits no notice.
 
-- **[placeholder]**
+## Notes
+
+- No new runtime dependency — native `fetch` plus `node:fs` / `node:os` /
+  `node:path` only.
+- The notice goes to stderr only; stdout / `--json` output and process exit codes
+  are untouched.

--- a/specs/022-version-update-check/pr-report.md
+++ b/specs/022-version-update-check/pr-report.md
@@ -1,0 +1,25 @@
+# PR Report: Check for new stable version on startup
+
+**Branch**: `022-version-update-check`
+**Date**: 2026-06-03
+**Spec**: [specs/022-version-update-check/spec.md](./spec.md)
+
+## Summary
+
+`azdo` now performs a lightweight, throttled, non-blocking check for a newer
+**stable** release on the npm registry and, when one is found, prints a single
+upgrade line to stderr after the command's own output. The check is best-effort
+— it never blocks the command, never changes the exit code, is suppressed in
+non-interactive output, and can be disabled with `--no-update-check`.
+
+## What's New
+
+<!-- finalised in step 11 -->
+
+- **[placeholder]**
+
+## Testing
+
+<!-- finalised in step 11 -->
+
+- **[placeholder]**

--- a/specs/022-version-update-check/quickstart.md
+++ b/specs/022-version-update-check/quickstart.md
@@ -1,0 +1,55 @@
+# Quickstart: Check for new stable version on startup
+
+**Feature**: 022-version-update-check | **Date**: 2026-06-01
+
+## What it does
+
+When you run any `azdo` command, the CLI occasionally checks npm for a newer **stable** release and, if one exists, prints a single line after the command output:
+
+```
+A new version of azdo-cli is available: 0.5.0 → 0.6.0. Run `npm i -g azdo-cli` to update.
+```
+
+The check runs at most **once every 10 minutes**, never blocks your command, and stays silent when it can't reach npm.
+
+## Try it
+
+```bash
+# Normal run — may show a one-line notice after output (at most once per 10 min)
+azdo get-item 123
+
+# Within 10 minutes, subsequent runs do NOT re-check or re-notify
+azdo get-item 124            # no notice (cached window)
+
+# Opt out for a single invocation
+azdo --no-update-check get-item 123
+
+# Scripted / piped (non-interactive) — notice is suppressed automatically
+azdo get-item 123 | cat      # no notice on stderr-less/non-TTY contexts
+```
+
+## Cache
+
+State lives at `~/.azdo/update-check.json`:
+
+```json
+{ "lastCheck": 1750000000000, "latestVersion": "0.6.0" }
+```
+
+Delete it any time to force a fresh check on the next run.
+
+## Verifying the behaviour (manual)
+
+1. **Notice appears**: temporarily set the running version below the published one (or delete the cache and ensure a newer version is published); run a command → one-line notice on stderr after output.
+2. **Throttle**: run twice within 10 minutes → only the first triggers a registry request; the second is silent.
+3. **Failure-safe**: disconnect the network, delete the cache, run a command → command works normally, no error, no notice, and `lastCheck` is NOT advanced (next run retries).
+4. **Opt-out**: `azdo --no-update-check ...` → no request, no notice.
+5. **Non-interactive**: pipe output or run in CI → no notice.
+
+## Tests
+
+```bash
+npm run test:unit      # unit tests for throttle, version compare, suppression, failure-safety
+npm test               # full build + unit + integration
+npm run lint
+```

--- a/specs/022-version-update-check/research.md
+++ b/specs/022-version-update-check/research.md
@@ -1,0 +1,75 @@
+# Research: Check for new stable version on startup
+
+**Feature**: 022-version-update-check | **Date**: 2026-06-01
+
+All decisions below resolve to existing project conventions and built-ins; no `NEEDS CLARIFICATION` remain (the four spec clarifications were answered by the owner on 2026-06-01).
+
+## R1: How to query npm for the latest stable version
+
+**Decision**: `GET https://registry.npmjs.org/azdo-cli/latest` via native `fetch`, read `.version`.
+
+**Rationale**:
+- The `latest` dist-tag is npm's definition of the current **stable** release; pre-releases are published under other tags and are excluded automatically (satisfies FR-006 without client-side pre-release filtering).
+- The `/<pkg>/latest` endpoint returns only the latest version's manifest (small payload) — faster and lighter than fetching the full packument `/<pkg>`.
+- Native `fetch` (Node 18+) means **no new dependency** (Constitution IV).
+
+**Alternatives rejected**:
+- `npm view azdo-cli version` via child process — spawns a process, far slower, depends on npm being on PATH.
+- Full packument `https://registry.npmjs.org/azdo-cli` — larger response, then we'd parse `dist-tags.latest` ourselves; unnecessary.
+- Third-party libs (`update-notifier`, `latest-version`) — pull in dependency trees; violates the minimal-deps principle.
+
+## R2: Timeout / non-blocking strategy
+
+**Decision**: Gate on the throttle **before** any network call; when a check is due, run `fetch` with an `AbortController` timeout (~1500 ms). Emit the notice from a commander `postAction` hook (requires `await program.parseAsync()`), so it prints after the command's own output.
+
+**Rationale**:
+- The common path (within the 10-min window) performs **zero** network I/O and a single small synchronous file read — effectively free, satisfying "quickest possible" and "must not block" (FR-004, SC-003).
+- A bounded timeout caps the rare fresh-check latency; a stalled registry can never hang the CLI.
+- `postAction` runs after the action handler, so the notice never interleaves with or delays command output.
+
+**Alternatives rejected**:
+- Fire-and-forget unawaited promise — lost when a command calls `process.exit()`, and an in-flight socket can delay process teardown unpredictably.
+- `preAction` hook — would delay the command itself.
+- Detached background/daemon process — massively over-engineered for a CLI.
+
+## R3: Cache location & format
+
+**Decision**: `~/.azdo/update-check.json`, an object `{ "lastCheck": <epoch ms>, "latestVersion": "<x.y.z>" }`.
+
+**Rationale**:
+- `config-store.ts` already establishes `~/.azdo/` (`path.join(os.homedir(), '.azdo', 'config.json')`) as the CLI's state dir — reuse it for discoverability and a single place for users to clear state.
+- Survives across invocations (the throttle requirement); a JSON object is trivial to read/validate/rewrite.
+
+**Alternatives rejected**:
+- `os.tmpdir()` — the issue says "temp file", but tmpdir can be cleared mid-window (weakening the throttle) and scatters CLI state. `~/.azdo/` is the established convention; functionally it is still a disposable cache. (Open to switching to tmpdir if the owner prefers strict "temp" semantics — noted for plan review.)
+- OS keychain (`@napi-rs/keyring`) — that's for secrets, not a public version string.
+
+## R4: Throttle & failure semantics (clarification 1)
+
+**Decision**: Only a **successful** check writes `lastCheck`. A failed/timed-out check leaves the cache untouched, so the next invocation is free to retry.
+
+**Rationale**: Directly encodes the owner's answer ("failed check should not reset the 10-min throttle"). Each attempt is itself bounded and non-blocking, so retry-on-next-command has no perceptible cost.
+
+## R5: Notice cadence (clarification 3)
+
+**Decision**: Print the single-line notice **only** on the invocation that performs a fresh successful check and finds `latestVersion > runningVersion`. No notice on cached-window invocations.
+
+**Rationale**: Ties "shown once per 10-minute window" to the act of checking — no extra "noticeShown" flag needed, and the next check after the window re-notifies ("After 10 minutes window the check will be notified again").
+
+## R6: Suppression (clarifications 2 & 4)
+
+**Decision**: Skip the entire feature when (a) `--no-update-check` is present, or (b) `!process.stderr.isTTY` (non-interactive). Also skip for `-v/--version` and the help output.
+
+**Rationale**: `--no-update-check` is the owner-chosen opt-out (FR-009). Non-TTY suppression keeps scripted/CI output clean (FR-011). Version/help are meta commands where an upgrade nag is noise.
+
+## R7: Version comparison (no new dependency)
+
+**Decision**: A small internal `isNewer(latest, current)` that compares dotted numeric components (major, minor, patch), treating any pre-release suffix as lower precedence; returns false on unpar;seable input.
+
+**Rationale**: The `latest` dist-tag is already stable semver, and the running version comes from `package.json` — a minimal numeric compare suffices without adding `semver` (Constitution IV). Unparseable/dev versions (e.g. `0.0.0`) simply yield no notice (FR-010).
+
+## R8: Error containment
+
+**Decision**: Wrap cache read, fetch, parse, compare, and cache write so any thrown error is caught and ignored; the function resolves to "no notice" and never rejects into the command path.
+
+**Rationale**: FR-007 (no errors surfaced) and FR-008 (corrupt/missing cache tolerated). The check is strictly best-effort.

--- a/specs/022-version-update-check/spec.md
+++ b/specs/022-version-update-check/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: Check for new stable version on startup
+
+**Feature Branch**: `022-version-update-check`  
+**Created**: 2026-06-01  
+**Status**: Draft  
+**Input**: User description: "Check for a new stable version on startup. When the user executes commands, azdo should check npm for a newer published stable version of the tool. Persist the last-check timestamp in a temp file so that no more than one check is performed every 10 minutes. The check must be the quickest possible and must not block or slow down normal command execution. If a newer stable version is available, inform the user. Source issue: alkampfergit/azdo-cli#47."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Notified when a newer stable version exists (Priority: P1)
+
+A user runs any `azdo` command from a version that is no longer the latest published stable release. After the command does its normal work, the user sees a short, unobtrusive notice that a newer stable version is available, along with how to upgrade. The notice never replaces, corrupts, or delays the command's own output.
+
+**Why this priority**: This is the core value of the feature — keeping users aware that an update exists so they can pick up fixes and improvements. Without it, the feature delivers nothing.
+
+**Independent Test**: With the local tool pinned to an older version number and the registry reporting a newer stable version, run any command and confirm a single upgrade notice appears after the command output, and that the command's own result is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** the installed tool is older than the latest published stable version, **When** the user runs any command, **Then** the command completes normally and an upgrade notice naming the newer version is shown afterwards.
+2. **Given** the installed tool is already at (or ahead of) the latest published stable version, **When** the user runs any command, **Then** no upgrade notice is shown.
+3. **Given** a newer version exists only as a pre-release/beta, **When** the user runs any command, **Then** no upgrade notice is shown (only stable releases trigger a notice).
+
+---
+
+### User Story 2 - Check is throttled and never slows commands down (Priority: P1)
+
+A user runs many `azdo` commands in quick succession (including in scripts). The tool must not perform a registry lookup on every invocation, and must never make the user wait on the network. At most one registry check happens per 10-minute window; all other invocations rely on the cached result.
+
+**Why this priority**: The issue explicitly requires the check to be the quickest possible, to not block command execution, and to run at most once per 10 minutes. A version check that slows down or stalls the CLI is worse than no check at all.
+
+**Independent Test**: Run a command, then run a second command within 10 minutes; confirm only one registry lookup occurred (second invocation used the cache). Simulate a slow/unreachable registry and confirm command latency is unaffected and the command still succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registry check ran less than 10 minutes ago, **When** the user runs another command, **Then** no new registry lookup is performed and the cached result is used.
+2. **Given** the last registry check was more than 10 minutes ago (or never), **When** the user runs a command, **Then** at most one new registry lookup is performed and the new timestamp/result is persisted.
+3. **Given** the registry is slow or unreachable, **When** the user runs a command, **Then** the command completes without added delay and no error is surfaced to the user.
+
+---
+
+### User Story 3 - Quietly degrades and can be turned off (Priority: P2)
+
+A user in a constrained environment (offline, air-gapped, CI pipeline, or simply not wanting the notice) is never blocked, never sees errors from the check, and can suppress the behaviour entirely.
+
+**Why this priority**: Keeps the feature safe and non-intrusive across all environments. Important for trust, but secondary to the check itself working.
+
+**Independent Test**: Set the opt-out control and confirm no registry lookup happens and no notice is shown. Run with no network and confirm commands behave exactly as before the feature existed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the opt-out control is set, **When** the user runs a command, **Then** no registry lookup and no upgrade notice occur.
+2. **Given** the cache file is missing, unreadable, or corrupt, **When** the user runs a command, **Then** the tool treats it as "no recent check", does not crash, and the command succeeds.
+
+---
+
+### Edge Cases
+
+- **Registry unreachable / timeout / offline**: the check fails silently; the command is unaffected and no error is shown. The failed attempt still updates the throttle timestamp so the tool does not retry on every subsequent command. [NEEDS CLARIFICATION: should a *failed* check reset the 10-minute throttle the same as a successful one, or should it be retried sooner?]
+- **Corrupt or partially written cache file**: treated as no recent check; overwritten on the next successful check.
+- **Concurrent invocations**: two commands started at nearly the same time must not corrupt the cache or produce duplicate prolonged checks; worst case is two lookups, never a crash.
+- **Pre-release / tagged versions**: only the latest *stable* release counts; pre-releases are ignored.
+- **Development / local builds** (running an unpublished or `0.0.0`-style version): no misleading "downgrade" notice should be shown.
+- **Non-interactive / CI execution**: [NEEDS CLARIFICATION: should the upgrade notice be automatically suppressed when output is not a terminal or when a CI environment is detected, to avoid polluting scripted/CI output?]
+- **Notice frequency**: because checks are throttled to once per 10 minutes, the notice is shown at most once per 10-minute window. [NEEDS CLARIFICATION: within a window where a newer version is known, should the notice appear on every command or only once until dismissed/upgraded?]
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The tool MUST, as part of normal command execution, determine whether a newer stable published version of itself is available.
+- **FR-002**: The tool MUST perform at most one registry lookup per 10-minute window, using a persisted record of the last check to enforce this.
+- **FR-003**: The tool MUST persist the last-check information in a temporary/cache location so the throttle survives across separate command invocations.
+- **FR-004**: The version check MUST NOT block, delay, or otherwise slow down the command the user actually invoked; the user's command and its output take priority.
+- **FR-005**: When a newer stable version is detected, the tool MUST inform the user with a short notice that names the available version and indicates how to upgrade.
+- **FR-006**: The tool MUST only consider stable releases when deciding whether to notify; pre-release/beta versions MUST NOT trigger a notice.
+- **FR-007**: The tool MUST NOT surface any error, stack trace, or warning to the user when the check fails for any reason (network, registry, parsing, file access).
+- **FR-008**: The tool MUST behave correctly and without crashing when the cache record is missing, unreadable, or corrupt.
+- **FR-009**: The tool MUST provide a way for the user to disable the version-check behaviour entirely. [NEEDS CLARIFICATION: opt-out mechanism — dedicated flag, config setting, environment variable, or a combination?]
+- **FR-010**: The tool MUST NOT show a misleading notice when the running version is equal to, or newer than, the latest published stable version (including local/development builds).
+
+### Key Entities *(include if feature involves data)*
+
+- **Last-check record**: the persisted state used to enforce throttling. Conceptually holds when the last check ran and the most recent known latest-stable version. Stored in a temporary/cache location, readable and writable across invocations, and safe to discard at any time.
+- **Latest-stable version**: the newest non-pre-release version of the tool published to the registry, compared against the currently running version.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When a newer stable version exists and the throttle allows, the user sees exactly one clear upgrade notice naming that version; when the running version is current, no notice appears.
+- **SC-002**: No more than one registry lookup occurs within any 10-minute window across repeated command invocations.
+- **SC-003**: Added latency to a command from the version-check feature is negligible in the common case and never causes the user to wait on the network — a slow or unreachable registry adds no perceptible delay to command completion.
+- **SC-004**: With the registry unreachable or the feature disabled, every command behaves exactly as it did before the feature existed (same exit codes, same output aside from the optional notice), with zero errors attributable to the check.

--- a/specs/022-version-update-check/spec.md
+++ b/specs/022-version-update-check/spec.md
@@ -5,6 +5,15 @@
 **Status**: Draft  
 **Input**: User description: "Check for a new stable version on startup. When the user executes commands, azdo should check npm for a newer published stable version of the tool. Persist the last-check timestamp in a temp file so that no more than one check is performed every 10 minutes. The check must be the quickest possible and must not block or slow down normal command execution. If a newer stable version is available, inform the user. Source issue: alkampfergit/azdo-cli#47."
 
+## Clarifications
+
+### Session 2026-06-01
+
+- Q: Should a *failed* check reset the 10-minute throttle, or be retried sooner? → A: A failed check MUST NOT reset the throttle — only a successful check updates the last-check timestamp, so the next invocation may retry. [owner: alkampfergit, 2026-06-01]
+- Q: Should the upgrade notice be suppressed in non-interactive / CI contexts? → A: Yes — suppress the notice when output is non-interactive. [owner: alkampfergit, 2026-06-01]
+- Q: Within a 10-minute window where a newer version is known, show the notice on every command or only once? → A: Only once — a single line in the output naming the new version and how to update. After the 10-minute window elapses, the check runs again and the user is notified again. [owner: alkampfergit, 2026-06-01]
+- Q: What is the opt-out mechanism? → A: A `--no-update-check` flag. [owner: alkampfergit, 2026-06-01]
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Notified when a newer stable version exists (Priority: P1)
@@ -56,13 +65,13 @@ A user in a constrained environment (offline, air-gapped, CI pipeline, or simply
 
 ### Edge Cases
 
-- **Registry unreachable / timeout / offline**: the check fails silently; the command is unaffected and no error is shown. The failed attempt still updates the throttle timestamp so the tool does not retry on every subsequent command. [NEEDS CLARIFICATION: should a *failed* check reset the 10-minute throttle the same as a successful one, or should it be retried sooner?]
+- **Registry unreachable / timeout / offline**: the check fails silently; the command is unaffected and no error is shown. A failed attempt does NOT update the last-check timestamp, so a subsequent invocation may retry the check.
 - **Corrupt or partially written cache file**: treated as no recent check; overwritten on the next successful check.
 - **Concurrent invocations**: two commands started at nearly the same time must not corrupt the cache or produce duplicate prolonged checks; worst case is two lookups, never a crash.
 - **Pre-release / tagged versions**: only the latest *stable* release counts; pre-releases are ignored.
 - **Development / local builds** (running an unpublished or `0.0.0`-style version): no misleading "downgrade" notice should be shown.
-- **Non-interactive / CI execution**: [NEEDS CLARIFICATION: should the upgrade notice be automatically suppressed when output is not a terminal or when a CI environment is detected, to avoid polluting scripted/CI output?]
-- **Notice frequency**: because checks are throttled to once per 10 minutes, the notice is shown at most once per 10-minute window. [NEEDS CLARIFICATION: within a window where a newer version is known, should the notice appear on every command or only once until dismissed/upgraded?]
+- **Non-interactive / CI execution**: the upgrade notice is suppressed when output is non-interactive, so scripted/CI output is not polluted.
+- **Notice frequency**: the notice is shown only once per 10-minute window (a single line). After the window elapses, the check runs again and the notice may be shown again.
 
 ## Requirements *(mandatory)*
 
@@ -70,14 +79,15 @@ A user in a constrained environment (offline, air-gapped, CI pipeline, or simply
 
 - **FR-001**: The tool MUST, as part of normal command execution, determine whether a newer stable published version of itself is available.
 - **FR-002**: The tool MUST perform at most one registry lookup per 10-minute window, using a persisted record of the last check to enforce this.
-- **FR-003**: The tool MUST persist the last-check information in a temporary/cache location so the throttle survives across separate command invocations.
+- **FR-003**: The tool MUST persist the last-check information in a temporary/cache location so the throttle survives across separate command invocations. Only a **successful** check updates the last-check timestamp; a failed check MUST leave the previous timestamp unchanged so a later invocation may retry.
 - **FR-004**: The version check MUST NOT block, delay, or otherwise slow down the command the user actually invoked; the user's command and its output take priority.
-- **FR-005**: When a newer stable version is detected, the tool MUST inform the user with a short notice that names the available version and indicates how to upgrade.
+- **FR-005**: When a newer stable version is detected, the tool MUST inform the user with a single-line notice that names the available version and indicates how to upgrade. The notice MUST be shown at most once per 10-minute window (not repeated on every command within the window); after the window elapses the notice may be shown again.
 - **FR-006**: The tool MUST only consider stable releases when deciding whether to notify; pre-release/beta versions MUST NOT trigger a notice.
 - **FR-007**: The tool MUST NOT surface any error, stack trace, or warning to the user when the check fails for any reason (network, registry, parsing, file access).
 - **FR-008**: The tool MUST behave correctly and without crashing when the cache record is missing, unreadable, or corrupt.
-- **FR-009**: The tool MUST provide a way for the user to disable the version-check behaviour entirely. [NEEDS CLARIFICATION: opt-out mechanism — dedicated flag, config setting, environment variable, or a combination?]
+- **FR-009**: The tool MUST provide a `--no-update-check` flag that disables the version-check behaviour (no registry lookup, no notice) for that invocation.
 - **FR-010**: The tool MUST NOT show a misleading notice when the running version is equal to, or newer than, the latest published stable version (including local/development builds).
+- **FR-011**: The tool MUST suppress the upgrade notice when output is non-interactive, so scripted/CI output is not polluted.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/022-version-update-check/tasks.md
+++ b/specs/022-version-update-check/tasks.md
@@ -1,0 +1,141 @@
+---
+
+description: "Task list for 022-version-update-check"
+---
+
+# Tasks: Check for new stable version on startup
+
+**Input**: Design documents from `/specs/022-version-update-check/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/update-check.md
+
+**Tests**: INCLUDED — the spec defines independent tests / measurable testing outcomes and `AGENTS.md` requires `npm test && npm run lint` to be green.
+
+**Organization**: Grouped by user story. NOTE: all three stories are delivered by the **same** module (`src/services/update-check.ts`) wired once in `src/index.ts`; implementation tasks that touch those two files are therefore sequential (not `[P]`), while test files (different paths) are `[P]`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 (or SETUP/FOUND/POLISH)
+
+## Path Conventions
+
+Single project: `src/`, `tests/` at repository root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 [SETUP] Confirm the toolchain builds clean before changes: `npm run build && npm run lint` (baseline green).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ CRITICAL**: Completes the testable core that all three stories rely on. No story work begins until this phase is done.
+
+- [ ] T002 [FOUND] Create `src/services/update-check.ts` skeleton: module-level constants `THROTTLE_MS = 10*60*1000`, `FETCH_TIMEOUT_MS = 1500`, `REGISTRY_URL = "https://registry.npmjs.org/azdo-cli/latest"`; export the `UpdateCheckDeps` interface and the `getUpdateNotice(opts?)` + `isNewer(latest, current)` signatures per `contracts/update-check.md`. Strict types, no `any`.
+- [ ] T003 [FOUND] Implement `isNewer(latest, current)`: dotted numeric compare (major/minor/patch), treat a pre-release suffix as lower precedence, return `false` on unparseable input (FR-006, FR-010).
+- [ ] T004 [FOUND] Implement cache I/O + type guard inside `update-check.ts`: default `readCache`/`writeCache` against `~/.azdo/update-check.json` (build the path from `os.homedir()`, mkdir the dir like `config-store.ts`); a `parseCache(raw): {lastCheck:number, latestVersion:string} | null` guard that returns `null` on missing/corrupt/wrong-shape input (FR-003, FR-008, data-model).
+- [ ] T005 [FOUND] Implement default `fetchLatest()`: native `fetch(REGISTRY_URL)` with an `AbortController` timeout of `FETCH_TIMEOUT_MS`, parse `.version` (string) from JSON, return it or `null`; never throw (R1, R2, FR-007).
+
+**Checkpoint**: Pure helpers (`isNewer`, cache parse, fetch wrapper) exist and are unit-testable with injected deps.
+
+---
+
+## Phase 3: User Story 1 - Notified when a newer stable version exists (Priority: P1) 🎯 MVP
+
+**Goal**: After a command, when a fresh successful check finds a newer stable version, emit one stderr line; otherwise nothing.
+
+**Independent Test**: Pin running version below a stubbed registry version → `getUpdateNotice` returns the notice; equal/newer or pre-release → returns `null`.
+
+### Tests for User Story 1
+
+- [ ] T006 [P] [US1] `tests/unit/update-check.test.ts` — `isNewer`: newer/equal/older/pre-release/unparseable cases (write first, expect fail).
+- [ ] T007 [P] [US1] In `tests/unit/update-check.test.ts` — `getUpdateNotice` returns the one-line notice (containing `current → latest` and the upgrade command) when throttle elapsed and stubbed `fetchLatest` returns a newer version; returns `null` when version is equal/older (C4, C5, C8).
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] In `update-check.ts`, implement the core flow of `getUpdateNotice`: read+parse cache → (throttle handled in US2) → call `fetchLatest` → on success write cache and, if `isNewer(latest, current)`, build the `UpdateNotice` line; return the string or `null`. Use injected `currentVersion` (default = `version` from `src/version.ts`). Wrap everything so it never throws (C4–C8, FR-005/007/010).
+- [ ] T009 [US1] Wire the caller in `src/index.ts`: switch `program.parse()` → `await program.parseAsync()`; after the command runs, call `getUpdateNotice(...)` and, if it returns a string, `process.stderr.write(notice + "\n")`. Notice prints **after** command output; exit code unchanged (contract: Caller).
+
+**Checkpoint**: Running an outdated build shows exactly one upgrade line on stderr after output; current build shows nothing.
+
+---
+
+## Phase 4: User Story 2 - Throttled and never slows commands down (Priority: P1)
+
+**Goal**: ≤1 registry lookup per 10-min window; a failed check does not reset the throttle; no perceptible delay.
+
+**Independent Test**: With `lastCheck` < 10 min old, `getUpdateNotice` performs no fetch (stub asserts not called). With a throwing/timeout `fetchLatest`, cache is left unchanged.
+
+### Tests for User Story 2
+
+- [ ] T010 [P] [US2] In `tests/unit/update-check.test.ts` — throttle: when injected clock puts `lastCheck` within `THROTTLE_MS`, `fetchLatest` is NOT called and result is `null` (C3, FR-002).
+- [ ] T011 [P] [US2] In `tests/unit/update-check.test.ts` — failure semantics: when `fetchLatest` rejects/returns null, `writeCache` is NOT called (cache unchanged) and result is `null` (C6, FR-003 clarification 1).
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] In `getUpdateNotice`, add the throttle gate before any network: if `now() - cache.lastCheck < THROTTLE_MS` return `null` immediately (no fetch). Only write the cache after a **successful** fetch (leave it untouched on failure) (FR-002/004, R4, R5).
+
+**Checkpoint**: Two runs within 10 min → one fetch; offline run → no error, `lastCheck` not advanced, command latency unaffected.
+
+---
+
+## Phase 5: User Story 3 - Quietly degrades and can be turned off (Priority: P2)
+
+**Goal**: `--no-update-check` and non-interactive output fully disable the feature; corrupt/missing cache is tolerated.
+
+**Independent Test**: `enabled:false` → returns `null`, no cache read/fetch. `isTTY()` false → returns `null`, no fetch. Corrupt cache → treated as no recent check, no throw.
+
+### Tests for User Story 3
+
+- [ ] T013 [P] [US3] In `tests/unit/update-check.test.ts` — `enabled:false` short-circuits (no cache read, no fetch) → `null` (C1); `isTTY()` false → `null`, no fetch (C2).
+- [ ] T014 [P] [US3] In `tests/unit/update-check.test.ts` — corrupt/missing cache (`readCache` returns garbage/null) is treated as `lastCheck=0`, proceeds to fetch, never throws (C7).
+
+### Implementation for User Story 3
+
+- [ ] T015 [US3] In `getUpdateNotice`, add the suppression guards first: return `null` when `enabled === false` or `!isTTY()` (defaults to `Boolean(process.stderr.isTTY)`), before any cache/fetch work (C1, C2, FR-009/011).
+- [ ] T016 [US3] In `src/index.ts`, register the global `--no-update-check` option on `program` and pass `{ enabled: program.opts().updateCheck }` to `getUpdateNotice`; skip the call entirely for `-v/--version` and help paths (FR-009, R6).
+
+**Checkpoint**: `azdo --no-update-check ...` and piped/CI runs are silent; corrupt cache never crashes a command.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T017 [P] [POLISH] Update docs: add a short "Update notifications" note (behaviour, 10-min throttle, `--no-update-check`, non-interactive suppression) to `docs/commands.md` (and README if it documents global options).
+- [ ] T018 [POLISH] Run `quickstart.md` manual validation steps 1–5 (notice / throttle / failure-safe / opt-out / non-interactive).
+- [ ] T019 [POLISH] Final gate: `npm test && npm run lint` green; confirm no new runtime dependency was added to `package.json`.
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (T001)** → **Foundational (T002–T005)** blocks everything.
+- **US1 (T006–T009)** is the MVP; depends on Foundational.
+- **US2 (T010–T012)** and **US3 (T013–T016)** depend on Foundational and build on the same `getUpdateNotice` body; sequence US1 → US2 → US3 because they edit the same function/files.
+- **Polish (T017–T019)** last.
+
+### Within each story
+
+- Write the listed tests first and confirm they fail before implementing.
+- `isNewer` / cache / fetch helpers (Foundational) before the orchestration body.
+- Service body before entrypoint wiring.
+
+### Parallel opportunities
+
+- Test tasks T006/T007/T010/T011/T013/T014 all live in the same `tests/unit/update-check.test.ts` — write together but they are one file (treat `[P]` as "independent cases", not separate files).
+- T017 (docs) is genuinely parallel to code once behaviour is final.
+- Implementation tasks on `src/services/update-check.ts` and `src/index.ts` are **sequential** (same files) — do not parallelise.
+
+---
+
+## Implementation Strategy
+
+**MVP** = Setup + Foundational + US1 (notice appears). Then layer US2 (throttle/safety) and US3 (suppression/opt-out), each independently testable, then polish. Commit after each story group with task IDs in the message.
+
+## Notes
+
+- No new runtime dependency (native `fetch` + `node:fs/os/path`).
+- Notice → stderr only; stdout/JSON and exit codes untouched.
+- All failure modes swallowed; the check is strictly best-effort.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,13 @@ import { createListFieldsCommand } from "./commands/list-fields.js";
 import { createPrCommand } from "./commands/pr.js";
 import { createCommentsCommand } from "./commands/comments.js";
 import { createDownloadAttachmentCommand } from "./commands/download-attachment.js";
+import { getUpdateNotice } from "./services/update-check.js";
 
 const program = new Command();
 
 program.name("azdo").description("Azure DevOps CLI tool").version(version, "-v, --version");
+
+program.option("--no-update-check", "Skip the check for a newer published version");
 
 program.addCommand(createGetItemCommand());
 program.addCommand(createAuthCommand());
@@ -36,8 +39,22 @@ program.addCommand(createDownloadAttachmentCommand());
 
 program.showHelpAfterError();
 
-program.parse();
+// After a command finishes, print a best-effort update notice on stderr.
+// The hook only fires for action commands, so -v/--version and help paths
+// are naturally skipped. Any failure is swallowed by getUpdateNotice itself.
+program.hook("postAction", async () => {
+  const notice = await getUpdateNotice({ enabled: program.opts().updateCheck });
+  if (notice) {
+    process.stderr.write(notice + "\n");
+  }
+});
 
-if (process.argv.length <= 2) {
-  program.help();
+async function main(): Promise<void> {
+  await program.parseAsync();
+
+  if (process.argv.length <= 2) {
+    program.help();
+  }
 }
+
+void main();

--- a/src/services/update-check.ts
+++ b/src/services/update-check.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { version as runningVersion } from "../version.js";
+
+/** 10-minute throttle window between successful registry checks. */
+export const THROTTLE_MS = 10 * 60 * 1000;
+/** Abort timeout for the registry request. */
+export const FETCH_TIMEOUT_MS = 1500;
+/** The `latest` dist-tag endpoint returns the stable manifest (excludes pre-releases). */
+export const REGISTRY_URL = "https://registry.npmjs.org/azdo-cli/latest";
+
+/**
+ * Injectable dependencies. They exist purely so unit tests run with no real
+ * I/O (clock, fs, fetch, TTY, version are all stubbable).
+ */
+export interface UpdateCheckDeps {
+  now?: () => number;
+  readCache?: () => string | null;
+  writeCache?: (data: string) => void;
+  fetchLatest?: () => Promise<string | null>;
+  isTTY?: () => boolean;
+  currentVersion?: string;
+}
+
+interface UpdateCheckCache {
+  lastCheck: number;
+  latestVersion: string;
+}
+
+/** Path to the local update-check cache, alongside the existing `~/.azdo/` state. */
+export function getCachePath(): string {
+  return path.join(os.homedir(), ".azdo", "update-check.json");
+}
+
+function defaultReadCache(): string | null {
+  try {
+    return fs.readFileSync(getCachePath(), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function defaultWriteCache(data: string): void {
+  try {
+    const cachePath = getCachePath();
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, data);
+  } catch {
+    // Best-effort cache: a write failure must never surface to the user.
+  }
+}
+
+/**
+ * Parse the raw cache contents into a typed entry, or `null` when the input is
+ * missing, non-JSON, or fails the shape guard (treated as "no recent check").
+ */
+export function parseCache(raw: string | null): UpdateCheckCache | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const { lastCheck, latestVersion } = parsed as Record<string, unknown>;
+  if (typeof lastCheck !== "number" || !Number.isFinite(lastCheck)) return null;
+  if (typeof latestVersion !== "string" || latestVersion.length === 0) return null;
+  return { lastCheck, latestVersion };
+}
+
+async function defaultFetchLatest(): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(REGISTRY_URL, { signal: controller.signal });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    if (typeof body !== "object" || body === null) return null;
+    const v = (body as Record<string, unknown>).version;
+    return typeof v === "string" && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface ParsedVersion {
+  release: [number, number, number];
+  prerelease: boolean;
+}
+
+function parseVersion(v: string): ParsedVersion | null {
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim().replace(/^v/, "");
+  const match = /^(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/.exec(trimmed);
+  if (!match) return null;
+  const release: [number, number, number] = [Number(match[1]), Number(match[2]), Number(match[3])];
+  if (!release.every(Number.isFinite)) return null;
+  return { release, prerelease: match[4] !== undefined };
+}
+
+/**
+ * Numeric semver comparison: is `latest` strictly newer than `current`?
+ * Dotted major/minor/patch compare; a pre-release suffix ranks below the
+ * matching release. Returns `false` on any unparseable input.
+ */
+export function isNewer(latest: string, current: string): boolean {
+  const a = parseVersion(latest);
+  const b = parseVersion(current);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a.release[i] > b.release[i]) return true;
+    if (a.release[i] < b.release[i]) return false;
+  }
+  // Release numbers are equal: release > pre-release.
+  if (a.prerelease && !b.prerelease) return false;
+  if (!a.prerelease && b.prerelease) return true;
+  return false;
+}
+
+/**
+ * Best-effort update check. Resolves to a one-line notice string when a fresh,
+ * successful check finds a newer stable version, otherwise `null`. NEVER throws,
+ * NEVER blocks beyond the bounded fetch, NEVER writes to stdout/stderr itself.
+ */
+export async function getUpdateNotice(
+  opts?: { enabled?: boolean } & UpdateCheckDeps,
+): Promise<string | null> {
+  try {
+    const {
+      enabled = true,
+      now = Date.now,
+      readCache = defaultReadCache,
+      writeCache = defaultWriteCache,
+      fetchLatest = defaultFetchLatest,
+      isTTY = () => Boolean(process.stderr.isTTY),
+      currentVersion = runningVersion,
+    } = opts ?? {};
+
+    // Suppression guards first — no cache read, no fetch (C1, C2).
+    if (enabled === false) return null;
+    if (!isTTY()) return null;
+
+    // Throttle gate: corrupt/missing cache is treated as lastCheck = 0 (C3, C7).
+    const cache = parseCache(readCache());
+    const lastCheck = cache?.lastCheck ?? 0;
+    if (now() - lastCheck < THROTTLE_MS) return null;
+
+    // Fresh check. A failure (null / throw) leaves the cache untouched (C6).
+    const latest = await fetchLatest();
+    if (!latest) return null;
+
+    // Success: advance the throttle window.
+    writeCache(JSON.stringify({ lastCheck: now(), latestVersion: latest }));
+
+    if (isNewer(latest, currentVersion)) {
+      return `A new version of azdo-cli is available: ${currentVersion} → ${latest}. Run \`npm i -g azdo-cli\` to update.`;
+    }
+    return null;
+  } catch {
+    // Strictly best-effort: any unexpected error is swallowed.
+    return null;
+  }
+}

--- a/tests/unit/update-check.test.ts
+++ b/tests/unit/update-check.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  getUpdateNotice,
+  isNewer,
+  parseCache,
+  THROTTLE_MS,
+  type UpdateCheckDeps,
+} from "../../src/services/update-check.js";
+
+/**
+ * Build a fully-stubbed deps object so no test touches the real clock, fs,
+ * network, or TTY. Individual tests override only what they care about.
+ */
+function deps(overrides: Partial<{ enabled: boolean } & UpdateCheckDeps> = {}) {
+  const writeCache = vi.fn();
+  const fetchLatest = vi.fn(async () => "0.6.0");
+  const base = {
+    enabled: true,
+    now: () => 10_000_000,
+    readCache: () => null as string | null,
+    writeCache,
+    fetchLatest,
+    isTTY: () => true,
+    currentVersion: "0.5.0",
+  };
+  return { opts: { ...base, ...overrides }, writeCache, fetchLatest };
+}
+
+describe("isNewer", () => {
+  it("returns true when latest is strictly newer (patch/minor/major)", () => {
+    expect(isNewer("0.5.1", "0.5.0")).toBe(true);
+    expect(isNewer("0.6.0", "0.5.9")).toBe(true);
+    expect(isNewer("1.0.0", "0.9.9")).toBe(true);
+  });
+
+  it("returns false when versions are equal", () => {
+    expect(isNewer("0.5.0", "0.5.0")).toBe(false);
+  });
+
+  it("returns false when latest is older", () => {
+    expect(isNewer("0.5.0", "0.6.0")).toBe(false);
+    expect(isNewer("0.4.9", "0.5.0")).toBe(false);
+  });
+
+  it("ranks a pre-release below the matching release", () => {
+    expect(isNewer("1.2.3-beta.1", "1.2.3")).toBe(false);
+    expect(isNewer("1.2.3", "1.2.3-beta.1")).toBe(true);
+  });
+
+  it("tolerates a leading v and build metadata", () => {
+    expect(isNewer("v0.6.0", "0.5.0")).toBe(true);
+    expect(isNewer("0.6.0+build.7", "0.5.0")).toBe(true);
+  });
+
+  it("returns false on unparseable input", () => {
+    expect(isNewer("not-a-version", "0.5.0")).toBe(false);
+    expect(isNewer("0.6.0", "garbage")).toBe(false);
+    expect(isNewer("", "")).toBe(false);
+  });
+});
+
+describe("parseCache", () => {
+  it("returns null for missing/empty/non-JSON input", () => {
+    expect(parseCache(null)).toBeNull();
+    expect(parseCache("")).toBeNull();
+    expect(parseCache("{not json")).toBeNull();
+  });
+
+  it("returns null for wrong-shape input", () => {
+    expect(parseCache(JSON.stringify({ lastCheck: "nope", latestVersion: "1.0.0" }))).toBeNull();
+    expect(parseCache(JSON.stringify({ lastCheck: 1, latestVersion: "" }))).toBeNull();
+    expect(parseCache(JSON.stringify({ lastCheck: Infinity, latestVersion: "1.0.0" }))).toBeNull();
+    expect(parseCache(JSON.stringify([1, 2, 3]))).toBeNull();
+  });
+
+  it("parses a valid cache entry", () => {
+    const raw = JSON.stringify({ lastCheck: 123, latestVersion: "0.6.0" });
+    expect(parseCache(raw)).toEqual({ lastCheck: 123, latestVersion: "0.6.0" });
+  });
+});
+
+describe("getUpdateNotice — User Story 1 (notice when newer stable exists)", () => {
+  it("returns the one-line notice when a fresh check finds a newer version (C4)", async () => {
+    const { opts, writeCache } = deps();
+    const notice = await getUpdateNotice(opts);
+    expect(notice).toContain("0.5.0 → 0.6.0");
+    expect(notice).toContain("npm i -g azdo-cli");
+    expect(writeCache).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when the registry version equals the current version (C5)", async () => {
+    const { opts, writeCache } = deps({ fetchLatest: vi.fn(async () => "0.5.0") });
+    expect(await getUpdateNotice(opts)).toBeNull();
+    // cache is still written on a successful (if uninteresting) check
+    expect(writeCache).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when the registry version is older than current (C8)", async () => {
+    const { opts } = deps({ fetchLatest: vi.fn(async () => "0.4.0") });
+    expect(await getUpdateNotice(opts)).toBeNull();
+  });
+
+  it("returns null for an unparseable current version (dev/local build) (C8)", async () => {
+    const { opts } = deps({ currentVersion: "0.0.0-dev" + "?" });
+    expect(await getUpdateNotice(opts)).toBeNull();
+  });
+});
+
+describe("getUpdateNotice — User Story 2 (throttle + failure safety)", () => {
+  it("does not fetch when lastCheck is within the throttle window (C3)", async () => {
+    const now = 10_000_000;
+    const { opts, fetchLatest } = deps({
+      now: () => now,
+      readCache: () => JSON.stringify({ lastCheck: now - (THROTTLE_MS - 1), latestVersion: "0.6.0" }),
+    });
+    expect(await getUpdateNotice(opts)).toBeNull();
+    expect(fetchLatest).not.toHaveBeenCalled();
+  });
+
+  it("does fetch when the throttle window has elapsed", async () => {
+    const now = 10_000_000;
+    const { opts, fetchLatest } = deps({
+      now: () => now,
+      readCache: () => JSON.stringify({ lastCheck: now - (THROTTLE_MS + 1), latestVersion: "0.5.0" }),
+    });
+    await getUpdateNotice(opts);
+    expect(fetchLatest).toHaveBeenCalledOnce();
+  });
+
+  it("leaves the cache unchanged when fetchLatest returns null (C6)", async () => {
+    const { opts, writeCache } = deps({ fetchLatest: vi.fn(async () => null) });
+    expect(await getUpdateNotice(opts)).toBeNull();
+    expect(writeCache).not.toHaveBeenCalled();
+  });
+
+  it("leaves the cache unchanged when fetchLatest throws (C6)", async () => {
+    const { opts, writeCache } = deps({
+      fetchLatest: vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    });
+    expect(await getUpdateNotice(opts)).toBeNull();
+    expect(writeCache).not.toHaveBeenCalled();
+  });
+});
+
+describe("getUpdateNotice — User Story 3 (suppression + tolerance)", () => {
+  it("short-circuits when disabled: no cache read, no fetch (C1)", async () => {
+    const readCache = vi.fn(() => null);
+    const { opts, fetchLatest } = deps({ enabled: false, readCache });
+    expect(await getUpdateNotice(opts)).toBeNull();
+    expect(readCache).not.toHaveBeenCalled();
+    expect(fetchLatest).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits in non-interactive output: no fetch (C2)", async () => {
+    const { opts, fetchLatest } = deps({ isTTY: () => false });
+    expect(await getUpdateNotice(opts)).toBeNull();
+    expect(fetchLatest).not.toHaveBeenCalled();
+  });
+
+  it("treats a corrupt cache as lastCheck=0, proceeds to fetch, never throws (C7)", async () => {
+    const { opts, fetchLatest } = deps({ readCache: () => "{garbage" });
+    const notice = await getUpdateNotice(opts);
+    expect(fetchLatest).toHaveBeenCalledOnce();
+    expect(notice).toContain("0.5.0 → 0.6.0");
+  });
+
+  it("treats a missing cache as lastCheck=0, proceeds to fetch (C7)", async () => {
+    const { opts, fetchLatest } = deps({ readCache: () => null });
+    await getUpdateNotice(opts);
+    expect(fetchLatest).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
# PR Report: Check for new stable version on startup

**Branch**: `022-version-update-check`
**Date**: 2026-06-03
**Spec**: [specs/022-version-update-check/spec.md](./spec.md)

## Summary

`azdo` now performs a lightweight, throttled, non-blocking check for a newer
**stable** release on the npm registry and, when one is found, prints a single
upgrade line to stderr after the command's own output. The check is best-effort
— it never blocks the command, never changes the exit code, is suppressed in
non-interactive output, and can be disabled with `--no-update-check`.

## What's New

- **Update-check service (`src/services/update-check.ts`)**: a new self-contained
  module that reads a small `~/.azdo/update-check.json` cache, throttles registry
  lookups to at most one per 10 minutes, fetches the `latest` stable version from
  `registry.npmjs.org` under a 1500 ms abort timeout, compares it numerically
  against the running version, and returns a one-line notice only when a fresh,
  successful check finds something newer. Every step is wrapped so it can never
  throw or block the user's command.
- **CLI wiring (`src/index.ts`)**: a global `--no-update-check` flag, the entry
  point switched to `parseAsync()`, and a `postAction` hook that writes the
  notice to **stderr after** the command's own output. The hook does not fire for
  `-v/--version` or help, so those paths stay silent.
- **Failure & suppression semantics**: the notice is suppressed when output is
  non-interactive (`!process.stderr.isTTY`) or when `--no-update-check` is set; a
  failed/timed-out check leaves the cache unchanged so the throttle window is not
  reset; a corrupt or missing cache is tolerated as "no recent check".
- **Docs (`docs/commands.md`)**: a new "Update notifications" section describing
  the behaviour, the 10-minute throttle, the `--no-update-check` opt-out, and the
  non-interactive suppression.

## Testing

- **Unit (`tests/unit/update-check.test.ts`, 21 cases)**: cover contract cases
  C1–C8 — suppression (disabled / non-TTY), throttle (within / elapsed window),
  failure safety (fetch returns null or throws → cache untouched), tolerant cache
  parsing (corrupt / missing / wrong-shape), and `isNewer` semantics (newer /
  equal / older / pre-release precedence / `v` prefix / build metadata /
  unparseable). All dependencies (clock, fs, fetch, TTY, version) are injected so
  no test performs real I/O.
- **Full suite**: `npm run lint`, `npm run typecheck`, `npm run build`, and
  `npm test` (757 passed, 7 skipped, 0 failed) all green.
- **Manual smoke**: `azdo --help` lists `--no-update-check`; `azdo
  --no-update-check config list` runs without crashing and emits no notice.

## Notes

- No new runtime dependency — native `fetch` plus `node:fs` / `node:os` /
  `node:path` only.
- The notice goes to stderr only; stdout / `--json` output and process exit codes
  are untouched.


Closes #47
