### PR TITLE
feat(#50): better support for PR comments and status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,10 @@ Check [AGENTS.md](/workspaces/azdo-cli/AGENTS.md) for the real repository guidan
 Skills live in `.agents/skills`.
 
 ## Recent Changes
+- 023-pr-comments-status: Added TypeScript 5.x (strict mode) + commander.js, native `fetch` (no new runtime deps)
 - 020-auth-docs-sync: Synced the authentication docs (`README.md`, `docs/commands.md`, `docs/linux-credential-store.md`) with the current `develop` auth surface — documented `azdo auth login` (OAuth default) alongside the PAT fallback. Documentation-only; no source or dependency changes (verified against the built CLI's `--help`).
 - 017-pr-comments-threads: Fixed `azdo pr comments` crash (tolerant `_links`, libuv-safe exit). Added `--pr-number <N>`, `--hide-resolved`, and `pr comment-resolve` / `pr comment-reopen` subcommands. No new runtime deps; kept the existing TypeScript 5.x / commander.js / native `fetch` stack.
 
 ## Active Technologies
-- Documentation only — no new technologies; existing TypeScript 5.x / Node.js LTS / commander.js stack (020-auth-docs-sync)
+- TypeScript 5.x (strict mode) + commander.js, native `fetch` (no new runtime deps) (023-pr-comments-status)
+- N/A (stateless CLI; reads Azure DevOps REST) (023-pr-comments-status)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ azdo comments add 12345 "Investigating the root cause now."
 # PR comment threads — list, filter, target by number, resolve or reopen
 azdo pr comments                        # active-branch PR
 azdo pr comments --pr-number 64         # any PR by number (skips branch lookup)
-azdo pr comments --pr-number 64 --hide-resolved
+azdo pr comments --pr-number 64 --hide-resolved      # or --exclude-resolved (alias)
+azdo pr comments --code-related-only    # only file/line-anchored threads
+azdo pr status                          # PR checks (status + branch policies) + code-comment counts
 azdo pr comment-resolve 17 --pr-number 64   # idempotent: exit 0 even when already resolved
 azdo pr comment-reopen 17  --pr-number 64
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,7 +13,7 @@
 | `azdo get-md-field <id> <field>` | Get rich-text field as markdown | `--download-images`, `--resize-images <px>`, `--images-path <dir>`, `--org`, `--project` |
 | `azdo set-md-field <id> <field> [content]` | Set markdown field | `--file`, `--json`, `--org`, `--project` |
 | `azdo list-fields <id>` | List all fields of a work item | `--json`, `--org`, `--project` |
-| `azdo pr <subcommand>` | Manage pull requests (current branch or by `--pr-number`) | `status`, `open`, `comments`, `comment-resolve`, `comment-reopen`, `--pr-number`, `--hide-resolved`, `--json`, `--org`, `--project` |
+| `azdo pr <subcommand>` | Manage pull requests (current branch or by `--pr-number`) | `status`, `open`, `comments`, `comment-resolve`, `comment-reopen`, `--pr-number`, `--hide-resolved`, `--exclude-resolved`, `--code-related-only`, `--json`, `--org`, `--project` |
 | `azdo config <subcommand>` | Manage saved settings | `set`, `get`, `list`, `unset`, `wizard`, `--json` |
 | `azdo auth login` | Authenticate against an org — OAuth (Microsoft Entra) by default, or a PAT with `--use-pat` | `--org`, `--use-pat`, `--device-code`, `--client-id`, `--tenant-id`, `--scopes`, `--from-stdin`, `--no-browser` |
 | `azdo auth` | Legacy PAT-prompt entry point (back-compat alias of `azdo auth login --use-pat`) | `--org`, `--from-stdin`, `--no-browser` |
@@ -101,14 +101,19 @@ azdo pr open --title "…" --description "…"      # open PR targeting develop
 azdo pr comments                           # list threads for current branch's PR
 azdo pr comments --pr-number 64            # list threads for any PR by number
 azdo pr comments --hide-resolved           # triage view — hide settled threads
+azdo pr comments --exclude-resolved        # alias of --hide-resolved
+azdo pr comments --code-related-only       # only threads anchored to a file/line
 azdo pr comment-resolve  17 --pr-number 64 # mark thread as resolved (idempotent)
 azdo pr comment-reopen   17 --pr-number 64 # reopen a previously resolved thread
 ```
 
 **`azdo pr status`**
 - Lists PRs for the current branch, including Azure DevOps checks
+- **Checks merge two sources**: the Pull Request Status API *and* branch **policy evaluations** (build validation, required reviewers, etc.). Branch-policy checks are the green checks the Azure DevOps UI shows and are not returned by the status endpoint, so both are combined. Each check carries a `source` of `status` or `policy` in `--json`.
+- `Checks: none reported by Azure DevOps` is shown only when both sources are genuinely empty; a retrieval failure shows `Checks: unable to retrieve (…)` instead (never silently "none")
 - Shows `Detail: …` for failed/errored checks when description is available
-- `--json` includes a `checks` array per PR
+- Shows a `Code comments: N open, M closed` line counting only **code-anchored** (file/line) threads; general discussion threads are excluded
+- `--json` includes a `checks` array (with `source`) and a `codeCommentCounts` object per PR
 
 **`azdo pr open`**
 - Requires `--title` and `--description`
@@ -120,7 +125,9 @@ azdo pr comment-reopen   17 --pr-number 64 # reopen a previously resolved thread
 - Lists every comment thread on the target PR with a bracketed status indicator (`[active]`, `[pending]`, `[resolved]`) next to each thread title
 - `--pr-number <N>` targets any PR by numeric id and bypasses the current-branch lookup entirely; invalid numbers and missing PRs fail cleanly with non-zero exit, no crash
 - When `--pr-number` is omitted, the active PR is auto-detected as the open PR whose source branch equals `refs/heads/<current branch>`. If zero or more than one open PR matches, the command fails (exit 1) with a message naming the searched branch — pass `--pr-number` to disambiguate. (`pr status` is unaffected: it remains a multi-PR overview that lists all matches.)
-- `--hide-resolved` drops threads whose backend state is settled (`fixed`, `wontFix`, `closed`, `byDesign`) — useful when triaging only the threads that still need attention
+- `--hide-resolved` (and its alias `--exclude-resolved`) drops threads whose backend state is settled (`fixed`, `wontFix`, `closed`, `byDesign`) — useful when triaging only the threads that still need attention
+- `--code-related-only` shows only threads anchored to a real file/line, omitting general discussion threads
+- The two filters are independent and combinable; with neither flag the output is unchanged. Both are honoured in `--json` output
 - Tolerant of Azure DevOps responses that omit `_links.web` (root cause of the original crash reported in issue #34)
 
 **`azdo pr comment-resolve <threadId>`**

--- a/specs/023-pr-comments-status/checklists/requirements.md
+++ b/specs/023-pr-comments-status/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Better support for commenting in the pull request
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- No [NEEDS CLARIFICATION] markers were emitted: the three concerns are
+  well-bounded. Two informed defaults (definition of "code comment" =
+  file-anchored thread; resolved/open state mapping) are recorded in the
+  Assumptions section and will be confirmed in `/speckit-clarify`.

--- a/specs/023-pr-comments-status/contracts/cli-commands.md
+++ b/specs/023-pr-comments-status/contracts/cli-commands.md
@@ -1,0 +1,118 @@
+# CLI Contract: 023-pr-comments-status (issue #50)
+
+Defines the observable command surface after this feature. Existing options
+unchanged unless noted.
+
+---
+
+## `azdo pr status`
+
+Check pull requests for the current branch, with **complete** check
+information and code-comment counts.
+
+### Options (unchanged)
+- `--org <org>`, `--project <project>`, `--json`
+
+### Behaviour changes
+
+**Checks (FR-001, FR-002).** The `Checks:` section now lists the union of:
+1. Pull Request **statuses** (existing `/statuses` source), and
+2. Branch **policy evaluations** (new `policy/evaluations` source).
+
+- When the union is non-empty: list every check as `- [<state>] <name>`.
+- When the union is empty **and** both fetches succeeded: print
+  `Checks: none reported by Azure DevOps`.
+- When a fetch **fails**: print a distinct line indicating checks could not
+  be retrieved (NOT "none"), e.g. `Checks: unable to retrieve (<reason>)`.
+
+**Code-comment counts (FR-007, FR-008).** A new line per PR, e.g.:
+
+```
+Code comments: 2 open, 5 closed
+```
+
+Counts code-anchored threads only (general threads excluded). Zero when no
+code-anchored threads exist.
+
+### Human output (example)
+
+```
+Pull requests for branch feature/x in repo myrepo:
+
+#123 [active] Add widget
+feature/x -> develop
+https://dev.azure.com/org/proj/_git/myrepo/pullrequest/123
+Checks:
+- [succeeded] Build/CI build validation
+- [succeeded] Required reviewers
+Code comments: 1 open, 3 closed
+```
+
+### JSON output (`--json`) — additive
+
+Each pull request object gains:
+
+```jsonc
+{
+  "id": 123,
+  "title": "Add widget",
+  "checks": [
+    { "id": 1, "state": "succeeded", "name": "Build/CI build validation", "source": "policy" }
+  ],
+  "codeCommentCounts": { "open": 1, "closed": 3 }
+}
+```
+
+Existing fields are preserved; only `checks[].source` and
+`codeCommentCounts` are added.
+
+---
+
+## `azdo pr comments`
+
+List comment threads for a pull request, with two new opt-in filters.
+
+### Options
+
+| Flag | Status | Meaning |
+|------|--------|---------|
+| `--org`, `--project`, `--pr-number <N>`, `--json` | unchanged | — |
+| `--hide-resolved` | **retained (alias)** | Hide resolved/won't-fix/closed/by-design threads. |
+| `--exclude-resolved` | **NEW** | Alias of `--hide-resolved` — identical effect. |
+| `--code-related-only` | **NEW** | Show only threads anchored to a file/line; omit general threads. |
+
+### Behaviour
+
+- `--code-related-only` keeps threads where `threadContext !== null`.
+- `--exclude-resolved` / `--hide-resolved` keep threads where
+  `isThreadResolved(status)` is false.
+- The two filters are **independent and combinable**; with both, only
+  unresolved code-anchored threads are shown.
+- **Default (no new flag): output is byte-for-byte unchanged** from the
+  prior release (FR-006, SC-005).
+- The filtered set is reflected in `--json` output as well (FR-010).
+
+### Filtered-to-empty messages
+
+When a filter removes all threads (but threads existed), print an
+informative line rather than nothing, consistent with the existing
+`--hide-resolved` empty message, e.g.:
+
+```
+No code-related comment threads for pull request #123.
+```
+```
+No unresolved comment threads for pull request #123.
+```
+
+(When both filters applied and nothing remains, the message names the
+combined filter.)
+
+---
+
+## Non-goals (explicit)
+
+- No new external service or provider; only an additional ADO REST endpoint
+  (`policy/evaluations`) and the Projects API for the project GUID.
+- No change to `pr comment`, `pr comment-resolve`, `pr comment-reopen`.
+- No version bump / release as part of this feature.

--- a/specs/023-pr-comments-status/data-model.md
+++ b/specs/023-pr-comments-status/data-model.md
@@ -1,0 +1,95 @@
+# Data Model: Better support for commenting in the pull request (023)
+
+**Feature**: 023-pr-comments-status · **Issue**: #50 · **Date**: 2026-06-03
+
+All types live in `src/types/pull-request.ts` (raw Azure DevOps shapes) and
+the domain shapes consumed by `src/commands/pr.ts`. This feature **extends**
+existing types; it introduces no new storage.
+
+---
+
+## 1. PullRequestCheck (existing — extended)
+
+The domain shape for a single check shown by `pr status`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `number` | Existing. Status id or policy evaluation id. |
+| `state` | `string` | Existing. Normalised state (e.g. `succeeded`, `failed`, `pending`, `error`). |
+| `name` | `string` | Existing. Display name (genre/name for statuses; policy display name for policy evaluations). |
+| `description` | `string \| null` | Existing. |
+| `targetUrl` | `string \| null` | Existing. |
+| `createdBy` | `string \| null` | Existing. |
+| `createdAt` | `string \| null` | Existing. |
+| `updatedAt` | `string \| null` | Existing. |
+| `source` | `'status' \| 'policy'` | **NEW (optional).** Where the check came from, so the union is explainable. Defaults to `'status'` for the existing path. |
+
+**State normalisation for policy evaluations.** Policy evaluation `status`
+values (`approved`, `rejected`, `running`, `queued`, `notApplicable`, …) map
+to the existing check states:
+
+| Policy status | Mapped `state` |
+|---------------|----------------|
+| `approved` | `succeeded` |
+| `rejected` | `failed` |
+| `running` / `queued` | `pending` |
+| `notApplicable` / `notSet` | dropped (consistent with `mapPullRequestCheck`) |
+
+---
+
+## 2. ActiveCommentThread (existing — unchanged)
+
+Already carries the field needed for code-vs-general classification.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `number` | Existing. |
+| `status` | `string` | Existing. Backend thread status; classified via `isThreadResolved`. |
+| `threadContext` | `string \| null` | Existing. File path anchor, or `null` for a general thread. **This is the code-vs-general discriminator.** |
+| `comments` | `ActivePullRequestComment[]` | Existing. |
+
+Derived predicates (no new fields):
+- **isCodeAnchored(thread)** ≡ `thread.threadContext !== null`.
+- **isResolved(thread)** ≡ `isThreadResolved(thread.status)` (existing).
+
+---
+
+## 3. PullRequestStatusPullRequest / PullRequestStatusResult (existing — extended)
+
+The per-PR block rendered by `pr status` gains comment counts.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id`, `title`, `status`, `sourceRefName`, `targetRefName`, `url` | — | Existing. |
+| `checks` | `PullRequestCheck[]` | Existing (now the union of statuses + policy evaluations). |
+| `codeCommentCounts` | `{ open: number; closed: number }` | **NEW.** Counts of code-anchored threads bucketed by resolved state. General threads excluded. |
+
+`PullRequestStatusResult` is unchanged in shape (`branch`, `repository`,
+`pullRequests[]`); each entry now includes `codeCommentCounts`.
+
+---
+
+## 4. CLI option shapes (commander.js)
+
+`PrCommandOptions` (the comments command options object) gains two booleans:
+
+| Option flag | Field | Default | Meaning |
+|-------------|-------|---------|---------|
+| `--code-related-only` | `codeRelatedOnly?: boolean` | `false` | Keep only threads with `threadContext !== null`. |
+| `--exclude-resolved` (alias of existing `--hide-resolved`) | `hideResolved?: boolean` | `false` | Drop resolved threads (`isThreadResolved`). |
+
+Both are opt-in; omitting both preserves current output (FR-006).
+
+---
+
+## Validation & invariants
+
+- **INV-1**: `codeCommentCounts.open + codeCommentCounts.closed` = number of
+  code-anchored threads on the PR (general threads never counted) — FR-008.
+- **INV-2**: A thread is classified open/closed by exactly one predicate
+  (`isThreadResolved`) everywhere (counts + `--exclude-resolved`) — FR-009.
+- **INV-3**: With neither comments flag set, the rendered/serialised thread
+  list is identical to pre-feature behaviour — FR-006, SC-005.
+- **INV-4**: `pr status` shows "none reported" only when both the status and
+  policy-evaluation collections are empty AND both fetches succeeded —
+  FR-001, FR-002.

--- a/specs/023-pr-comments-status/plan.md
+++ b/specs/023-pr-comments-status/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Better support for commenting in the pull request
+
+**Branch**: `023-pr-comments-status` | **Date**: 2026-06-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/023-pr-comments-status/spec.md` · **Issue**: #50
+
+## Summary
+
+Three improvements to the `azdo pr` command surface:
+
+1. **Fix `pr status` "no checks" defect (US1).** The command only reads the
+   PR Status API (`/statuses`), which misses **branch policy evaluations** —
+   the actual green checks shown in the ADO UI. Add a policy-evaluations
+   fetch and merge it with statuses; distinguish "genuinely none" from
+   "couldn't retrieve".
+2. **Add comment filters to `pr comments` (US2).** New `--code-related-only`
+   (file-anchored threads only) and `--exclude-resolved` (alias of the
+   existing `--hide-resolved`). Independent, combinable, default off.
+3. **Add code-comment counts to `pr status` (US3).** Fetch threads per PR and
+   show open/closed counts of code-anchored threads.
+
+The thread anchor (`threadContext.filePath`) and resolved-state mapping
+(`isThreadResolved`) already exist; the bulk of new work is the
+policy-evaluations source for US1.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode)
+**Primary Dependencies**: commander.js, native `fetch` (no new runtime deps)
+**Storage**: N/A (stateless CLI; reads Azure DevOps REST)
+**Testing**: vitest (unit tests under `tests/unit/`)
+**Target Platform**: Node.js LTS CLI, bundled with tsup
+**Project Type**: Single-project CLI
+**Performance Goals**: Interactive CLI; +1 policy fetch and +1 threads fetch per listed PR (typically 0–1 PRs) — negligible
+**Constraints**: No `any`; `--json` parity; no behavioural regression to existing flags
+**Scale/Scope**: ~2 source files (`src/services/pr-client.ts`, `src/commands/pr.ts`), 1 types file, docs, unit tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Compliance |
+|-----------|------------|
+| I. CLI-First Design | ✅ New flags are commander.js options; `--json` parity maintained (FR-010); meaningful output preserved. |
+| II. TypeScript Strictness | ✅ New types (`source`, `codeCommentCounts`, policy-evaluation shapes) explicitly typed; no `any`; type guards on REST responses. |
+| III. Single Responsibility | ✅ Data fetching stays in `pr-client.ts` service; formatting/filtering in `pr.ts` command; reuse `isThreadResolved`. No duplicated state logic. |
+| IV. npm Distribution | ✅ No new runtime dependency; tsup bundle unaffected. |
+| V. Simplicity | ✅ Reuse existing predicates/filters; `--exclude-resolved` is an alias, not a parallel path; one project-GUID lookup cached per command. No new abstractions. |
+
+**Post-design re-check**: PASS — no new violations introduced; no Complexity
+Tracking entries required.
+
+**Workflow note**: Constitution requires `README.md` to be reviewed/updated
+after the spec run (and `docs/commands.md`) — captured as a docs task.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-pr-comments-status/
+├── plan.md              # This file
+├── spec.md              # Approved spec
+├── research.md          # Phase 0 — R1..R6 decisions
+├── data-model.md        # Phase 1 — extended types
+├── quickstart.md        # Phase 1 — manual verification
+├── contracts/
+│   └── cli-commands.md  # Phase 1 — command surface
+└── tasks.md             # Phase 2 (/speckit.tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── commands/
+│   └── pr.ts                 # status + comments commands: new flags, filters,
+│                             #   counts, union checks rendering, empty-vs-error
+├── services/
+│   └── pr-client.ts          # getPullRequestChecks (merge policy evals),
+│                             #   new getPullRequestPolicyEvaluations,
+│                             #   resolveProjectId; reuse getPullRequestThreads
+└── types/
+    └── pull-request.ts       # PullRequestCheck.source, codeCommentCounts,
+                              #   Azdo policy-evaluation response shapes
+
+tests/
+└── unit/
+    ├── pr-comment-state.test.ts     # existing — extend for new filters
+    ├── pr-status-checks.test.ts     # checks union + empty-vs-error (new/extended)
+    └── pr-code-comment-counts.test.ts  # open/closed counting (new)
+
+docs/
+└── commands.md           # document new flags + status output
+README.md                 # constitution-required review/update
+```
+
+**Structure Decision**: Single-project CLI (existing layout). Service layer
+(`pr-client.ts`) owns all REST I/O and mapping; command layer (`pr.ts`) owns
+flag parsing, filtering, counting, and rendering. This matches the current
+separation and Principle III.
+
+## Implementation approach (per concern)
+
+### US1 — surface policy evaluations
+- Add `resolveProjectId(context, cred)` to `pr-client.ts`: `GET
+  _apis/projects/{project}` → `.id`; cache within the command invocation.
+- Add `getPullRequestPolicyEvaluations(context, repo, cred, projectId, prId)`:
+  `GET {project}/_apis/policy/evaluations?artifactId=vstfs:///CodeReview/CodeReviewId/{projectId}/{prId}`.
+  Map evaluation → `PullRequestCheck` (state normalisation per data-model);
+  drop `notApplicable`/`notSet`.
+- In `pr status`, fetch both sources, merge (`source` tags origin), and pass
+  the union to `formatPullRequestChecks`.
+- Make the empty-vs-error branch explicit: only print "none reported" when
+  both fetches succeed and the union is empty.
+
+### US2 — comments filters
+- `pr comments`: add `--code-related-only` (`codeRelatedOnly`) and
+  `--exclude-resolved` (mapped to the same `hideResolved` as
+  `--hide-resolved`). Apply `threadContext !== null` filter alongside the
+  existing resolved filter; compose. Update empty-result messaging to name
+  the active filter(s). Mirror in `--json`.
+
+### US3 — counts in status
+- `pr status`: per PR also call `getPullRequestThreads`, compute
+  `codeCommentCounts = { open, closed }` over code-anchored threads via
+  `isThreadResolved`, render a `Code comments:` line and add the field to
+  JSON.
+
+## Testing strategy (TDD)
+- Unit tests drive each concern against fixture REST payloads (no live ADO):
+  - checks union incl. policy evaluations + empty-vs-error (US1),
+  - `--code-related-only`, `--exclude-resolved` alias, and combination (US2),
+  - open/closed code-comment counting incl. general-thread exclusion (US3).
+- Existing `pr-comment-state.test.ts` must stay green (regression / FR-006).
+- `npm run lint && npm test && npm run build` all clean before ready.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/023-pr-comments-status/pr-report.md
+++ b/specs/023-pr-comments-status/pr-report.md
@@ -1,0 +1,32 @@
+# PR Report: Better support for commenting in the pull request
+
+**Branch**: `023-pr-comments-status`
+**Date**: 2026-06-03
+**Spec**: [specs/023-pr-comments-status/spec.md](./spec.md)
+
+## Summary
+
+Improves the `azdo pr status` and `azdo pr comments` commands. Fixes a defect
+where `pr status` reported "no checks" even when green branch-policy checks
+were running, adds two opt-in filters to `pr comments` for triaging review
+feedback, and surfaces open/closed code-comment counts in `pr status`.
+
+## What's New
+
+<!-- Finalised in speckit-gh step 11 -->
+
+- **[pr status — checks]**: [TBD]
+- **[pr comments — filters]**: [TBD]
+- **[pr status — counts]**: [TBD]
+
+## Testing
+
+<!-- Finalised in speckit-gh step 11 -->
+
+- **[Unit]**: [TBD]
+
+## Notes
+
+<!-- Finalised in speckit-gh step 11 -->
+
+- [TBD]

--- a/specs/023-pr-comments-status/pr-report.md
+++ b/specs/023-pr-comments-status/pr-report.md
@@ -10,23 +10,63 @@ Improves the `azdo pr status` and `azdo pr comments` commands. Fixes a defect
 where `pr status` reported "no checks" even when green branch-policy checks
 were running, adds two opt-in filters to `pr comments` for triaging review
 feedback, and surfaces open/closed code-comment counts in `pr status`.
+Closes #50.
 
 ## What's New
 
-<!-- Finalised in speckit-gh step 11 -->
+- **`pr status` — checks now include branch policy evaluations**: the command
+  previously read only the Pull Request *Status API*, which does not return
+  branch-policy results (build validation, required reviewers, …) — the green
+  checks shown in the Azure DevOps UI. It now also fetches **policy
+  evaluations** (resolving the project GUID via the Projects API) and shows the
+  merged set. Each check carries a `source` of `status` or `policy` in `--json`.
+- **`pr status` — honest empty-vs-error**: `Checks: none reported by Azure
+  DevOps` is shown only when both sources are genuinely empty. A retrieval
+  failure now shows `Checks: unable to retrieve (…)` instead of silently
+  reading as "none", and a check-fetch failure no longer aborts the whole
+  command.
+- **`pr status` — code-comment counts**: a new `Code comments: N open, M
+  closed` line counts only code-anchored (file/line) threads; general
+  discussion threads are excluded. Exposed as `codeCommentCounts` in `--json`.
+- **`pr comments` — `--code-related-only`**: shows only threads anchored to a
+  real file/line.
+- **`pr comments` — `--exclude-resolved`**: alias of the existing
+  `--hide-resolved`; either flag drops resolved/won't-fix/closed/by-design
+  threads. The two filters are independent and combinable; with neither flag,
+  output is unchanged.
+- **Docs**: `docs/commands.md` and `README.md` updated for the new flags and
+  status output.
 
-- **[pr status — checks]**: [TBD]
-- **[pr comments — filters]**: [TBD]
-- **[pr status — counts]**: [TBD]
+## Breaking Changes
+
+- **`pr status` no longer exits non-zero when the check lookup fails.**
+  Previously a failed checks fetch aborted the command with exit 1. It now
+  degrades gracefully: the PR is still listed and the checks line reads
+  `unable to retrieve (…)`. This is intentional (FR-002) — a transient checks
+  failure should not hide the PR, and "no checks" must never mask an error.
 
 ## Testing
 
-<!-- Finalised in speckit-gh step 11 -->
-
-- **[Unit]**: [TBD]
+- **Unit (vitest)**:
+  - `pr-client.test.ts`: policy-evaluation → check mapping with state
+    normalisation (approved→succeeded, rejected→failed, running/queued→pending,
+    notApplicable/notSet dropped), artifactId construction, and
+    `resolveProjectId`; existing status checks now assert `source: 'status'`.
+  - `pr-status.test.ts`: merged policy+status checks displayed; empty-vs-error
+    (`unable to retrieve`, no abort); open/closed code-comment counts incl.
+    general-thread exclusion and the zero case; updated `--json` shape.
+  - `pr-comments-filters.test.ts`: `--code-related-only`, `--exclude-resolved`
+    (≡ `--hide-resolved`), combination, the no-flag regression, and the
+    filtered-to-empty message.
+- **Gate**: `npm run lint` clean, `npx tsc --noEmit` clean, `npm test` =
+  768 passed / 7 pre-existing skips, `npm run build` clean.
 
 ## Notes
 
-<!-- Finalised in speckit-gh step 11 -->
-
-- [TBD]
+- `npm run format` (prettier `--check`) reports pre-existing style warnings
+  across ~41 unrelated `src/` files; the repo baseline is not prettier-clean
+  and `format` is not part of the lint/test/build gate, so no unrelated
+  reformatting was done.
+- The live `quickstart.md` spot-check requires a real Azure DevOps PR with a
+  green build-validation policy; it is provided for manual verification and was
+  not run in CI (no live ADO credentials in the test environment).

--- a/specs/023-pr-comments-status/quickstart.md
+++ b/specs/023-pr-comments-status/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Better support for commenting in the pull request (023)
+
+Manual verification steps once implemented. Requires a real Azure DevOps PR
+with: at least one passing branch-policy build validation, and a mix of
+code-anchored + general comment threads, some resolved.
+
+## 0. Build
+
+```bash
+npm run lint && npm test && npm run build
+```
+
+## 1. Status checks are surfaced (US1)
+
+```bash
+azdo pr status            # on a branch with an open PR that has green policy checks
+```
+
+Expect the `Checks:` section to **list the green checks** (policy
+evaluations + statuses), NOT `none reported`. Confirm `--json` carries the
+same checks with a `source` of `policy` or `status`.
+
+On a PR genuinely without any checks, expect `Checks: none reported by
+Azure DevOps`.
+
+## 2. Comment filters (US2)
+
+```bash
+azdo pr comments                          # baseline — unchanged from before
+azdo pr comments --code-related-only      # only file-anchored threads
+azdo pr comments --exclude-resolved       # only unresolved threads (alias of --hide-resolved)
+azdo pr comments --code-related-only --exclude-resolved   # unresolved code threads only
+```
+
+Verify each filter narrows the output as expected, that the two combine, and
+that the no-flag run matches the prior release exactly. Repeat with `--json`.
+
+## 3. Comment counts in status (US3)
+
+```bash
+azdo pr status
+```
+
+Expect a `Code comments: <open> open, <closed> closed` line counting only
+code-anchored threads. Cross-check against
+`azdo pr comments --code-related-only` (total) and
+`azdo pr comments --code-related-only --exclude-resolved` (open).
+
+## 4. Regression
+
+```bash
+npm test    # all existing pr tests stay green; new unit tests pass
+```

--- a/specs/023-pr-comments-status/research.md
+++ b/specs/023-pr-comments-status/research.md
@@ -1,0 +1,173 @@
+# Research: Better support for commenting in the pull request (023)
+
+**Feature**: 023-pr-comments-status · **Issue**: #50 · **Date**: 2026-06-03
+
+This document resolves the technical unknowns behind the three concerns in
+the spec, grounded in the current implementation.
+
+---
+
+## R1 — Why `azdo pr status` reports "no checks" when green checks exist (US1, the defect)
+
+**Finding.** `pr status` builds its checks list from a single source:
+`getPullRequestChecks()` (`src/services/pr-client.ts:233`) calls the Azure
+DevOps **Pull Request Status API**:
+
+```
+GET .../git/repositories/{repo}/pullRequests/{prId}/statuses?api-version=7.1
+```
+
+That endpoint returns only *statuses posted via the Status API* (third-party
+/ manual / external integrations). It does **not** return **branch policy
+evaluations** — and branch policies (Build Validation, Required Reviewers,
+Comment Resolution, Status checks required by policy, etc.) are exactly the
+"green checks" a user sees in the Azure DevOps PR UI. For the common case
+(a build-validation policy passing green) the `/statuses` collection is
+empty, so `formatPullRequestChecks()` (`src/commands/pr.ts:136`) prints
+`Checks: none reported by Azure DevOps` even though checks are clearly
+running. This is the reported bug.
+
+**Decision.** Surface **policy evaluations** in addition to statuses. Fetch:
+
+```
+GET .../{project}/_apis/policy/evaluations
+    ?artifactId=vstfs:///CodeReview/CodeReviewId/{projectId}/{prId}
+    &api-version=7.1
+```
+
+Map each evaluation's configuration type + status to the existing
+`PullRequestCheck` shape (name + state), merge with the Status-API results,
+and display the union. Reserve the "none reported" message for the case
+where **both** sources are genuinely empty.
+
+**Project GUID needed.** The policy `artifactId` requires the project
+**GUID**, but the raw PR object (`AzdoPullRequest`) and `AzdoContext` only
+carry the project **name**. Resolve the GUID once via the Projects API:
+
+```
+GET .../_apis/projects/{projectNameOrId}?api-version=7.1   → .id (GUID)
+```
+
+Cache it for the duration of the command (one lookup, not per-PR).
+
+**Error vs. empty distinction (FR-002).** If a checks/policy fetch *fails*
+(HTTP error, auth), the command must not silently say "none". Surface a
+distinct message (e.g. `Checks: unable to retrieve (…)`) so "genuinely
+none" is never confused with "couldn't retrieve". The existing
+`fetchWithErrors` / `HTTP_` error path is reused; only the empty-vs-error
+branching in the status command/formatter changes.
+
+**Alternatives considered.**
+- *Only fix the message wording* — rejected: the data is genuinely missing,
+  not just mislabelled. Users want to see the policy checks.
+- *Use the `pullRequests/{id}?includeCommits=false&...` expansion* —
+  rejected: PR expansion does not include policy evaluation states; the
+  dedicated policy/evaluations endpoint is the supported source.
+
+---
+
+## R2 — Definition of a "code comment" / "code-related" thread (US2, US3)
+
+**Finding.** A thread already exposes its file anchor: `mapThread()`
+(`src/services/pr-client.ts:112`) sets
+`threadContext: thread.threadContext?.filePath ?? null` on
+`ActiveCommentThread`. The formatter already prints `(general)` when
+`threadContext` is null (`src/commands/pr.ts:173`).
+
+**Decision.** "Code-related" / "code comment" = a thread whose
+`threadContext` (file path) is **non-null**. `--code-related-only` keeps
+threads with `threadContext !== null`; general threads (null) are dropped.
+The US3 counts use the same predicate. No new data is needed from the API —
+the field is already mapped.
+
+**Edge case (deleted file).** A thread anchored to a since-deleted file
+still carries a `threadContext.filePath`, so it remains "code-related" — the
+spec's stated default. No special handling required.
+
+---
+
+## R3 — Resolved vs. open thread-state mapping (US2 `--exclude-resolved`, US3 counts)
+
+**Finding.** The mapping already exists: `isThreadResolved()`
+(`src/services/pr-client.ts:153`) with
+`RESOLVED_THREAD_STATUSES = {fixed, wontFix, closed, byDesign}`. Everything
+else (`active`, `pending`, …) is treated as open. This already backs the
+existing `--hide-resolved` filter and the comment-resolve idempotency check.
+
+**Decision.** Reuse `isThreadResolved()` verbatim for both
+`--exclude-resolved` and the open/closed code-comment counts. "Closed code
+comments" = code-anchored threads where `isThreadResolved(status)` is true;
+"open code comments" = code-anchored threads where it is false. This keeps
+one single source of truth for the open/closed classification (FR-009).
+
+---
+
+## R4 — `--exclude-resolved` already exists as `--hide-resolved`
+
+**Finding.** `pr comments` **already** has a `--hide-resolved` flag
+(`src/commands/pr.ts:339`) with identical semantics to the requested
+`--exclude-resolved`. The issue author asked for `--exclude-resolved`,
+likely unaware of the existing flag (added in 017-pr-comments-threads).
+
+**Decision.** Add `--exclude-resolved` as an **alias** of the existing
+`--hide-resolved` rather than a second, divergent code path. commander.js
+supports multiple option names; map both to the same `hideResolved` boolean
+(or OR them). This satisfies FR-004/FR-006 with zero regression and avoids
+two flags that mean the same thing. Document `--exclude-resolved` as the
+primary name and `--hide-resolved` as a retained alias.
+
+**Alternatives considered.**
+- *Rename `--hide-resolved` → `--exclude-resolved`* — rejected: breaking
+  change for anyone already scripting `--hide-resolved` (violates FR-006 /
+  no-regression).
+- *Two independent flags* — rejected: redundant, confusing, and could
+  diverge.
+
+---
+
+## R5 — `--code-related-only` is a new, independent filter
+
+**Finding.** No existing flag filters by anchor. The filter is applied at the
+command layer over `getPullRequestThreads()` results (same place the
+`--hide-resolved` filter already lives, `src/commands/pr.ts:392`).
+
+**Decision.** Add `--code-related-only` as a new boolean option on
+`pr comments`. Apply it as a thread-list filter
+(`thread.threadContext !== null`) composable with the resolved filter; both
+default off so the no-flag output is unchanged (FR-005, FR-006). Reflect the
+filtered set in JSON output too (FR-010) — the existing `--json` branch
+serialises the same filtered `threads` array.
+
+---
+
+## R6 — Comment counts in `pr status` (US3)
+
+**Finding.** `pr status` currently fetches checks per PR but does **not**
+fetch threads. To show open/closed code-comment counts it must also fetch
+threads for each listed PR (reusing `getPullRequestThreads()`), then count
+code-anchored threads bucketed by `isThreadResolved`.
+
+**Decision.** For each PR in `pr status`, fetch threads, compute
+`openCodeComments` and `closedCodeComments` (code-anchored only), and render
+a one-line summary in the human output plus fields in the JSON result. The
+fetch mirrors the existing per-PR `getPullRequestChecks` `Promise.all` map
+in the status command (`src/commands/pr.ts:224`).
+
+**Performance note.** This adds one threads request per PR listed by
+`pr status` (typically 0–1 PRs for the current branch). Negligible; no
+batching needed (Constitution V — simplicity).
+
+---
+
+## Summary of decisions
+
+| # | Decision |
+|---|----------|
+| R1 | Fetch **policy evaluations** + statuses; resolve project GUID via Projects API; distinguish empty vs. error. |
+| R2 | "Code comment" = thread with non-null `threadContext.filePath` (already mapped). |
+| R3 | Reuse `isThreadResolved()` for `--exclude-resolved` and the open/closed counts. |
+| R4 | `--exclude-resolved` = **alias** of existing `--hide-resolved` (no rename, no regression). |
+| R5 | Add new `--code-related-only` filter; composable; default off; reflected in JSON. |
+| R6 | `pr status` also fetches threads to compute open/closed code-comment counts. |
+
+No `NEEDS CLARIFICATION` items remain.

--- a/specs/023-pr-comments-status/spec.md
+++ b/specs/023-pr-comments-status/spec.md
@@ -1,0 +1,200 @@
+# Feature Specification: Better support for commenting in the pull request
+
+**Feature Branch**: `023-pr-comments-status`  
+**Created**: 2026-06-03  
+**Status**: Draft  
+**Input**: User description: "Better support for commenting in the pull request. Improve azdo PR commenting and status: (1) `azdo pr status` reports no checks are present even though green checks run; (2) the output of `azdo pr comments` is confusing because many comments are not bound to code lines — add `--code-related-only` and `--exclude-resolved` flags; (3) in `azdo pr status` show a count of opened and closed comments, counting only code (file-anchored) comments."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Status checks are actually shown (Priority: P1)
+
+A reviewer runs `azdo pr status` on a pull request that has status checks
+(build/CI validations) running or completed. Today the command reports
+that no checks are present even when there are green (succeeded) checks on
+the PR. The reviewer needs the command to faithfully list the checks that
+Azure DevOps reports for the pull request, with their state.
+
+**Why this priority**: This is a correctness defect — the command is
+actively misleading. A reviewer who trusts the output may believe a PR has
+no validation when it is in fact green (or red). Restoring trust in the
+core status output is the most critical item.
+
+**Independent Test**: Run `azdo pr status` against a PR known to have at
+least one completed status check and confirm the command lists that check
+and its state instead of "no checks".
+
+**Acceptance Scenarios**:
+
+1. **Given** a pull request that has one or more status checks reported by
+   Azure DevOps (e.g. a succeeded build validation), **When** the user runs
+   `azdo pr status` for that PR, **Then** the command lists each check with
+   its name and outcome (e.g. succeeded/failed/pending) and does NOT claim
+   that no checks are present.
+2. **Given** a pull request that genuinely has no status checks configured,
+   **When** the user runs `azdo pr status`, **Then** the command clearly
+   states that no checks are present (the "no checks" message is reserved
+   for the genuinely-empty case only).
+3. **Given** a pull request with a mix of succeeded and pending/failed
+   checks, **When** the user runs `azdo pr status`, **Then** every reported
+   check appears with its correct individual state.
+
+---
+
+### User Story 2 - Filter PR comments to what matters (Priority: P1)
+
+A reviewer runs `azdo pr comments` and is overwhelmed because the output
+mixes general discussion threads (not tied to any code) with threads
+anchored to specific files/lines, and it also includes threads that have
+already been resolved. The reviewer wants two independent opt-in filters:
+show only code-anchored comments, and/or hide resolved threads.
+
+**Why this priority**: This is the primary usability complaint in the
+issue. The two filters are independent and each delivers value on its own,
+making the command usable for code-review triage.
+
+**Independent Test**: On a PR that has both file-anchored and
+non-file-anchored threads, and both resolved and unresolved threads, run
+`azdo pr comments` with each new flag and confirm the output is filtered
+accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR with both code-anchored threads and general (non-code)
+   threads, **When** the user runs `azdo pr comments --code-related-only`,
+   **Then** only threads anchored to a real file/line are shown and general
+   discussion threads are omitted.
+2. **Given** a PR with both resolved and unresolved threads, **When** the
+   user runs `azdo pr comments --exclude-resolved`, **Then** resolved
+   threads are omitted and only unresolved (open) threads remain.
+3. **Given** the same PR, **When** the user combines
+   `--code-related-only --exclude-resolved`, **Then** only unresolved
+   code-anchored threads are shown.
+4. **Given** the user runs `azdo pr comments` with neither new flag,
+   **Then** the output is unchanged from today's behaviour (the flags are
+   opt-in and default to off).
+
+---
+
+### User Story 3 - Comment counts in the status overview (Priority: P2)
+
+A reviewer running `azdo pr status` wants an at-a-glance count of how many
+code (file-anchored) comments are open versus closed, so they can judge how
+much review feedback is still outstanding without scrolling through the
+full comments list.
+
+**Why this priority**: This is a convenience summary that builds on the
+same code-vs-general distinction as Story 2. It is valuable but secondary
+to the two correctness/usability items above.
+
+**Independent Test**: On a PR with a known number of open and closed
+code-anchored comment threads, run `azdo pr status` and confirm the
+reported open/closed code-comment counts match.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR with code-anchored comment threads in both open and
+   resolved states, **When** the user runs `azdo pr status`, **Then** the
+   output includes a count of open code comments and a count of closed
+   (resolved) code comments.
+2. **Given** a PR whose only comment threads are general (non-code),
+   **When** the user runs `azdo pr status`, **Then** the code-comment
+   counts are reported as zero (general threads are excluded from the
+   count).
+3. **Given** a PR with no comment threads at all, **When** the user runs
+   `azdo pr status`, **Then** the counts are reported as zero without error.
+
+---
+
+### Edge Cases
+
+- A thread that has comments but no file/line anchor → treated as a general
+  (non-code) thread: excluded by `--code-related-only` and excluded from the
+  code-comment counts.
+- A thread anchored to a file that no longer exists in the latest iteration
+  (deleted file) → still counts as a code-anchored thread (it carries a file
+  context), unless clarified otherwise.
+- A thread in a state that is neither clearly "active/open" nor "resolved"
+  (e.g. pending, won't-fix, closed-by-default) → must map deterministically
+  to either the open or closed bucket for counting and for
+  `--exclude-resolved`.
+- A PR with checks the user is not authorised to see, or where the checks
+  data returns an error → the command must not silently report "no checks";
+  it should distinguish "genuinely none" from "could not retrieve".
+- Machine-readable (JSON) output mode, if supported, must carry the same
+  filtered set and the same counts as the human-readable output.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `azdo pr status` MUST list every status check that Azure
+  DevOps reports for the pull request, each with its name and individual
+  state, whenever at least one check exists.
+- **FR-002**: `azdo pr status` MUST report "no checks" only when the pull
+  request genuinely has zero status checks, and MUST distinguish that case
+  from a failure to retrieve check data.
+- **FR-003**: `azdo pr comments` MUST accept a `--code-related-only` flag
+  that, when set, restricts the output to threads anchored to a specific
+  file/line and omits general (non-file-anchored) threads.
+- **FR-004**: `azdo pr comments` MUST accept an `--exclude-resolved` flag
+  that, when set, omits threads in a resolved state and shows only
+  unresolved (open) threads.
+- **FR-005**: The two flags MUST be independent and combinable; using both
+  yields only unresolved code-anchored threads.
+- **FR-006**: Both flags MUST default to off — omitting them preserves the
+  current `azdo pr comments` output and behaviour (no regression).
+- **FR-007**: `azdo pr status` MUST display a count of open code comments
+  and a count of closed/resolved code comments, where "code comment" means
+  a thread anchored to a file/line.
+- **FR-008**: The comment counts in `azdo pr status` MUST exclude general
+  (non-file-anchored) threads.
+- **FR-009**: The system MUST classify each thread deterministically as
+  open or closed for both `--exclude-resolved` and the status counts, using
+  a consistent mapping of Azure DevOps thread states.
+- **FR-010**: If the project supports machine-readable (JSON) output for
+  these commands, the filtered comment set and the new counts MUST be
+  reflected there as well, not only in human-readable output.
+- **FR-011**: The new flags and counts MUST be documented in the command
+  help text and the user-facing docs.
+
+### Key Entities *(include if feature involves data)*
+
+- **PR status check**: A validation reported by Azure DevOps against the
+  pull request (e.g. a build/CI run or policy evaluation), with a name and a
+  state (e.g. succeeded, failed, pending).
+- **Comment thread**: A discussion on the pull request. May be
+  *code-anchored* (tied to a specific file and line) or *general* (no file
+  context). Has a state that maps to open or closed/resolved.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For any PR that has at least one status check, `azdo pr
+  status` shows 100% of the reported checks and never displays "no checks"
+  — verified against PRs with green, red, and mixed check states.
+- **SC-002**: With `--code-related-only`, the comments output contains only
+  file-anchored threads (zero general threads) on a PR that mixes both.
+- **SC-003**: With `--exclude-resolved`, the comments output contains zero
+  resolved threads on a PR that mixes resolved and unresolved threads.
+- **SC-004**: The open/closed code-comment counts reported by `azdo pr
+  status` exactly match the number of open and resolved file-anchored
+  threads on the PR.
+- **SC-005**: Running `azdo pr comments` with no new flags produces output
+  identical to the prior release (no behavioural regression).
+
+## Assumptions
+
+- "Code comment" / "code-related" means a thread that carries a file/line
+  anchor (thread context), as opposed to a general PR discussion thread.
+- "Resolved" maps to Azure DevOps thread states that represent completion
+  (e.g. fixed/closed/won't-fix); "open" maps to active/pending states. The
+  exact state-to-bucket mapping is confirmed during clarification/plan.
+- The new flags are opt-in filters layered on the existing `azdo pr
+  comments` command; they do not change defaults.
+- The status-check defect is a data-surfacing bug in how the existing `azdo
+  pr status` reads/displays the checks Azure DevOps already returns, not a
+  request for a new checks source or provider.
+- These changes are CLI-surface and presentation improvements; no new
+  external service integration is introduced.

--- a/specs/023-pr-comments-status/tasks.md
+++ b/specs/023-pr-comments-status/tasks.md
@@ -1,0 +1,124 @@
+---
+description: "Task list for feature 023-pr-comments-status"
+---
+
+# Tasks: Better support for commenting in the pull request
+
+**Input**: Design documents from `/specs/023-pr-comments-status/` · **Issue**: #50
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/cli-commands.md
+
+**Tests**: TDD requested — vitest unit tests are written before/with each implementation slice.
+
+**Organization**: Grouped by user story (US1 fix checks · US2 comment filters · US3 status counts). Each story is independently testable.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: parallelizable (different file, no incomplete dependency)
+- Single-project layout: `src/`, `tests/` at repo root.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm baseline is green on branch `023-pr-comments-status`: run `npm run lint && npm test && npm run build` and note any pre-existing failures before changing code.
+
+---
+
+## Phase 2: Foundational (blocking prerequisites)
+
+Type extensions shared across stories — must land before story implementation.
+
+- [ ] T002 [P] Add Azure DevOps policy-evaluation response shapes to `src/types/pull-request.ts` (`AzdoPolicyEvaluationListResponse`, `AzdoPolicyEvaluation` with `configuration.type.displayName`/`status`/`evaluationId`), plus a `AzdoProject` shape (`{ id: string }`) for the Projects API. No `any`.
+- [ ] T003 [P] Extend `PullRequestCheck` in `src/types/pull-request.ts` with optional `source?: 'status' | 'policy'`, and extend the `pr status` per-PR result type with `codeCommentCounts: { open: number; closed: number }`.
+
+**Checkpoint**: Types compile (`npx tsc --noEmit`); no behaviour change yet.
+
+---
+
+## Phase 3: User Story 1 — Status checks are actually shown (P1) 🎯 MVP
+
+**Goal**: `pr status` lists branch policy evaluations + statuses; "none" only when genuinely empty; distinguish fetch error from empty.
+
+**Independent test**: `azdo pr status` on a PR with a green build-validation policy lists the check instead of "none reported".
+
+### Tests (write first)
+- [ ] T004 [P] [US1] Add `tests/unit/pr-status-checks.test.ts`: map a policy-evaluation payload to `PullRequestCheck` (state normalisation approved→succeeded, rejected→failed, running/queued→pending, notApplicable/notSet dropped), and assert merged union with statuses. (Test must fail initially.)
+- [ ] T005 [P] [US1] In the same test file, assert empty-vs-error: union empty + both fetches OK ⇒ "none reported"; a fetch error ⇒ a distinct "unable to retrieve" outcome (not "none").
+
+### Implementation
+- [ ] T006 [US1] Add `resolveProjectId(context, cred)` to `src/services/pr-client.ts`: `GET _apis/projects/{project}?api-version=7.1` → `.id`; memoise within the call. Reuse `fetchWithErrors`/`readJsonResponse`.
+- [ ] T007 [US1] Add `getPullRequestPolicyEvaluations(context, repo, cred, projectId, prId)` to `src/services/pr-client.ts`: `GET {project}/_apis/policy/evaluations?artifactId=vstfs:///CodeReview/CodeReviewId/{projectId}/{prId}&api-version=7.1`; add `mapPolicyEvaluationCheck` mapping → `PullRequestCheck` (`source: 'policy'`), dropping notApplicable/notSet (mirror `mapPullRequestCheck`).
+- [ ] T008 [US1] Tag existing status results with `source: 'status'` in `mapPullRequestCheck` (`src/services/pr-client.ts`).
+- [ ] T009 [US1] In `createPrStatusCommand` (`src/commands/pr.ts`): resolve project id once, fetch statuses + policy evaluations per PR, merge into `checks`. Track per-source fetch success so the empty-vs-error decision is possible.
+- [ ] T010 [US1] Update `formatPullRequestChecks` (`src/commands/pr.ts`) to print the union, and only emit `Checks: none reported by Azure DevOps` when both sources succeeded and the union is empty; emit a distinct `Checks: unable to retrieve (…)` line when a fetch failed.
+- [ ] T011 [US1] Ensure `--json` output for `pr status` includes merged `checks` with `source`. Verify T004/T005 pass.
+
+**Checkpoint**: US1 independently shippable — `pr status` surfaces policy checks.
+
+---
+
+## Phase 4: User Story 2 — Filter PR comments (P1)
+
+**Goal**: `--code-related-only` and `--exclude-resolved` (alias of existing `--hide-resolved`), independent + combinable, default off.
+
+**Independent test**: on a PR mixing anchored/general and resolved/unresolved threads, each flag narrows output; no-flag output unchanged.
+
+### Tests (write first)
+- [ ] T012 [P] [US2] Extend `tests/unit/pr-comment-state.test.ts` (or add `tests/unit/pr-comments-filters.test.ts`): assert `--code-related-only` keeps only `threadContext !== null` threads; `--exclude-resolved` behaves identically to `--hide-resolved`; both compose to unresolved-code-only; and no-flag output is unchanged (regression, FR-006). (Fails initially.)
+
+### Implementation
+- [ ] T013 [US2] In `createPrCommentsCommand` (`src/commands/pr.ts`): add `--code-related-only` option (`codeRelatedOnly`) and `--exclude-resolved` option mapped to the same `hideResolved` boolean as `--hide-resolved` (OR them; keep both names). Update `PrCommandOptions`/comments-options type.
+- [ ] T014 [US2] Apply the `threadContext !== null` filter alongside the existing resolved filter (compose, order-independent) in the comments action; reflect the filtered set in both human and `--json` output.
+- [ ] T015 [US2] Update the empty-result messaging to name the active filter(s) (e.g. "No code-related comment threads…", "No unresolved comment threads…"). Verify T012 passes.
+
+**Checkpoint**: US2 independently shippable — comment filters work, no regression.
+
+---
+
+## Phase 5: User Story 3 — Code-comment counts in status (P2)
+
+**Goal**: `pr status` shows open/closed counts of code-anchored threads.
+
+**Independent test**: counts match the number of open vs resolved file-anchored threads; general threads excluded; zero when none.
+
+### Tests (write first)
+- [ ] T016 [P] [US3] Add `tests/unit/pr-code-comment-counts.test.ts`: from a thread set (mix of anchored/general, resolved/active), assert `{ open, closed }` counts code-anchored only, via `isThreadResolved`; general threads excluded; empty ⇒ `{0,0}`. (Fails initially.)
+
+### Implementation
+- [ ] T017 [US3] In `createPrStatusCommand` (`src/commands/pr.ts`): also call `getPullRequestThreads` per PR and compute `codeCommentCounts = { open, closed }` over code-anchored threads using `isThreadResolved`.
+- [ ] T018 [US3] Render a `Code comments: N open, M closed` line per PR in human output and add `codeCommentCounts` to the `--json` result. Verify T016 passes.
+
+**Checkpoint**: US3 shippable — status shows comment counts.
+
+---
+
+## Phase 6: Polish & cross-cutting
+
+- [ ] T019 [P] Update `docs/commands.md`: document `pr status` policy-evaluation checks + `Code comments` line, and `pr comments` `--code-related-only` / `--exclude-resolved` (alias of `--hide-resolved`).
+- [ ] T020 [P] Review/update `README.md` per constitution (new flags + status output), if the PR surface is described there.
+- [ ] T021 Finalise the PR report (`specs/023-pr-comments-status/pr-report.md`) — What's New / Testing sections (done in speckit-gh step 11).
+- [ ] T022 Full gate: `npm run lint && npm test && npm run build` all green; manual quickstart spot-check from `quickstart.md` if a live PR is available.
+
+---
+
+## Dependencies & order
+
+- **Setup (T001)** → **Foundational (T002–T003)** → stories.
+- **US1 (T004–T011)** depends only on Foundational. **MVP = US1.**
+- **US2 (T012–T015)** depends only on Foundational — independent of US1.
+- **US3 (T016–T018)** depends on Foundational; conceptually related to US2 (shared code-anchored predicate) but independently testable.
+- **Polish (T019–T022)** after the stories it documents.
+
+Story phases are independent and could be done in parallel by separate agents; within a phase, tests precede implementation (TDD).
+
+## Parallel execution examples
+
+- Foundational: `T002` and `T003` in parallel (same file `types/pull-request.ts` — coordinate or do sequentially if conflicting; mark [P] only because logically distinct).
+- Tests `T004`, `T005` (US1), `T012` (US2), `T016` (US3) are in different test files → parallelizable.
+- Docs `T019`, `T020` parallel.
+
+## Implementation strategy
+
+1. Ship **US1** first (the reported bug, highest value) → validate `pr status`.
+2. Add **US2** filters.
+3. Add **US3** counts.
+4. Polish docs + final gate.

--- a/specs/023-pr-comments-status/tasks.md
+++ b/specs/023-pr-comments-status/tasks.md
@@ -19,7 +19,7 @@ description: "Task list for feature 023-pr-comments-status"
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm baseline is green on branch `023-pr-comments-status`: run `npm run lint && npm test && npm run build` and note any pre-existing failures before changing code.
+- [X] T001 Confirm baseline is green on branch `023-pr-comments-status`: run `npm run lint && npm test && npm run build` and note any pre-existing failures before changing code.
 
 ---
 
@@ -27,8 +27,8 @@ description: "Task list for feature 023-pr-comments-status"
 
 Type extensions shared across stories — must land before story implementation.
 
-- [ ] T002 [P] Add Azure DevOps policy-evaluation response shapes to `src/types/pull-request.ts` (`AzdoPolicyEvaluationListResponse`, `AzdoPolicyEvaluation` with `configuration.type.displayName`/`status`/`evaluationId`), plus a `AzdoProject` shape (`{ id: string }`) for the Projects API. No `any`.
-- [ ] T003 [P] Extend `PullRequestCheck` in `src/types/pull-request.ts` with optional `source?: 'status' | 'policy'`, and extend the `pr status` per-PR result type with `codeCommentCounts: { open: number; closed: number }`.
+- [X] T002 [P] Add Azure DevOps policy-evaluation response shapes to `src/types/pull-request.ts` (`AzdoPolicyEvaluationListResponse`, `AzdoPolicyEvaluation` with `configuration.type.displayName`/`status`/`evaluationId`), plus a `AzdoProject` shape (`{ id: string }`) for the Projects API. No `any`.
+- [X] T003 [P] Extend `PullRequestCheck` in `src/types/pull-request.ts` with optional `source?: 'status' | 'policy'`, and extend the `pr status` per-PR result type with `codeCommentCounts: { open: number; closed: number }`.
 
 **Checkpoint**: Types compile (`npx tsc --noEmit`); no behaviour change yet.
 
@@ -41,16 +41,16 @@ Type extensions shared across stories — must land before story implementation.
 **Independent test**: `azdo pr status` on a PR with a green build-validation policy lists the check instead of "none reported".
 
 ### Tests (write first)
-- [ ] T004 [P] [US1] Add `tests/unit/pr-status-checks.test.ts`: map a policy-evaluation payload to `PullRequestCheck` (state normalisation approved→succeeded, rejected→failed, running/queued→pending, notApplicable/notSet dropped), and assert merged union with statuses. (Test must fail initially.)
-- [ ] T005 [P] [US1] In the same test file, assert empty-vs-error: union empty + both fetches OK ⇒ "none reported"; a fetch error ⇒ a distinct "unable to retrieve" outcome (not "none").
+- [X] T004 [P] [US1] Add `tests/unit/pr-status-checks.test.ts`: map a policy-evaluation payload to `PullRequestCheck` (state normalisation approved→succeeded, rejected→failed, running/queued→pending, notApplicable/notSet dropped), and assert merged union with statuses. (Test must fail initially.)
+- [X] T005 [P] [US1] In the same test file, assert empty-vs-error: union empty + both fetches OK ⇒ "none reported"; a fetch error ⇒ a distinct "unable to retrieve" outcome (not "none").
 
 ### Implementation
-- [ ] T006 [US1] Add `resolveProjectId(context, cred)` to `src/services/pr-client.ts`: `GET _apis/projects/{project}?api-version=7.1` → `.id`; memoise within the call. Reuse `fetchWithErrors`/`readJsonResponse`.
-- [ ] T007 [US1] Add `getPullRequestPolicyEvaluations(context, repo, cred, projectId, prId)` to `src/services/pr-client.ts`: `GET {project}/_apis/policy/evaluations?artifactId=vstfs:///CodeReview/CodeReviewId/{projectId}/{prId}&api-version=7.1`; add `mapPolicyEvaluationCheck` mapping → `PullRequestCheck` (`source: 'policy'`), dropping notApplicable/notSet (mirror `mapPullRequestCheck`).
-- [ ] T008 [US1] Tag existing status results with `source: 'status'` in `mapPullRequestCheck` (`src/services/pr-client.ts`).
-- [ ] T009 [US1] In `createPrStatusCommand` (`src/commands/pr.ts`): resolve project id once, fetch statuses + policy evaluations per PR, merge into `checks`. Track per-source fetch success so the empty-vs-error decision is possible.
-- [ ] T010 [US1] Update `formatPullRequestChecks` (`src/commands/pr.ts`) to print the union, and only emit `Checks: none reported by Azure DevOps` when both sources succeeded and the union is empty; emit a distinct `Checks: unable to retrieve (…)` line when a fetch failed.
-- [ ] T011 [US1] Ensure `--json` output for `pr status` includes merged `checks` with `source`. Verify T004/T005 pass.
+- [X] T006 [US1] Add `resolveProjectId(context, cred)` to `src/services/pr-client.ts`: `GET _apis/projects/{project}?api-version=7.1` → `.id`; memoise within the call. Reuse `fetchWithErrors`/`readJsonResponse`.
+- [X] T007 [US1] Add `getPullRequestPolicyEvaluations(context, repo, cred, projectId, prId)` to `src/services/pr-client.ts`: `GET {project}/_apis/policy/evaluations?artifactId=vstfs:///CodeReview/CodeReviewId/{projectId}/{prId}&api-version=7.1`; add `mapPolicyEvaluationCheck` mapping → `PullRequestCheck` (`source: 'policy'`), dropping notApplicable/notSet (mirror `mapPullRequestCheck`).
+- [X] T008 [US1] Tag existing status results with `source: 'status'` in `mapPullRequestCheck` (`src/services/pr-client.ts`).
+- [X] T009 [US1] In `createPrStatusCommand` (`src/commands/pr.ts`): resolve project id once, fetch statuses + policy evaluations per PR, merge into `checks`. Track per-source fetch success so the empty-vs-error decision is possible.
+- [X] T010 [US1] Update `formatPullRequestChecks` (`src/commands/pr.ts`) to print the union, and only emit `Checks: none reported by Azure DevOps` when both sources succeeded and the union is empty; emit a distinct `Checks: unable to retrieve (…)` line when a fetch failed.
+- [X] T011 [US1] Ensure `--json` output for `pr status` includes merged `checks` with `source`. Verify T004/T005 pass.
 
 **Checkpoint**: US1 independently shippable — `pr status` surfaces policy checks.
 
@@ -63,12 +63,12 @@ Type extensions shared across stories — must land before story implementation.
 **Independent test**: on a PR mixing anchored/general and resolved/unresolved threads, each flag narrows output; no-flag output unchanged.
 
 ### Tests (write first)
-- [ ] T012 [P] [US2] Extend `tests/unit/pr-comment-state.test.ts` (or add `tests/unit/pr-comments-filters.test.ts`): assert `--code-related-only` keeps only `threadContext !== null` threads; `--exclude-resolved` behaves identically to `--hide-resolved`; both compose to unresolved-code-only; and no-flag output is unchanged (regression, FR-006). (Fails initially.)
+- [X] T012 [P] [US2] Extend `tests/unit/pr-comment-state.test.ts` (or add `tests/unit/pr-comments-filters.test.ts`): assert `--code-related-only` keeps only `threadContext !== null` threads; `--exclude-resolved` behaves identically to `--hide-resolved`; both compose to unresolved-code-only; and no-flag output is unchanged (regression, FR-006). (Fails initially.)
 
 ### Implementation
-- [ ] T013 [US2] In `createPrCommentsCommand` (`src/commands/pr.ts`): add `--code-related-only` option (`codeRelatedOnly`) and `--exclude-resolved` option mapped to the same `hideResolved` boolean as `--hide-resolved` (OR them; keep both names). Update `PrCommandOptions`/comments-options type.
-- [ ] T014 [US2] Apply the `threadContext !== null` filter alongside the existing resolved filter (compose, order-independent) in the comments action; reflect the filtered set in both human and `--json` output.
-- [ ] T015 [US2] Update the empty-result messaging to name the active filter(s) (e.g. "No code-related comment threads…", "No unresolved comment threads…"). Verify T012 passes.
+- [X] T013 [US2] In `createPrCommentsCommand` (`src/commands/pr.ts`): add `--code-related-only` option (`codeRelatedOnly`) and `--exclude-resolved` option mapped to the same `hideResolved` boolean as `--hide-resolved` (OR them; keep both names). Update `PrCommandOptions`/comments-options type.
+- [X] T014 [US2] Apply the `threadContext !== null` filter alongside the existing resolved filter (compose, order-independent) in the comments action; reflect the filtered set in both human and `--json` output.
+- [X] T015 [US2] Update the empty-result messaging to name the active filter(s) (e.g. "No code-related comment threads…", "No unresolved comment threads…"). Verify T012 passes.
 
 **Checkpoint**: US2 independently shippable — comment filters work, no regression.
 
@@ -81,11 +81,11 @@ Type extensions shared across stories — must land before story implementation.
 **Independent test**: counts match the number of open vs resolved file-anchored threads; general threads excluded; zero when none.
 
 ### Tests (write first)
-- [ ] T016 [P] [US3] Add `tests/unit/pr-code-comment-counts.test.ts`: from a thread set (mix of anchored/general, resolved/active), assert `{ open, closed }` counts code-anchored only, via `isThreadResolved`; general threads excluded; empty ⇒ `{0,0}`. (Fails initially.)
+- [X] T016 [P] [US3] Add `tests/unit/pr-code-comment-counts.test.ts`: from a thread set (mix of anchored/general, resolved/active), assert `{ open, closed }` counts code-anchored only, via `isThreadResolved`; general threads excluded; empty ⇒ `{0,0}`. (Fails initially.)
 
 ### Implementation
-- [ ] T017 [US3] In `createPrStatusCommand` (`src/commands/pr.ts`): also call `getPullRequestThreads` per PR and compute `codeCommentCounts = { open, closed }` over code-anchored threads using `isThreadResolved`.
-- [ ] T018 [US3] Render a `Code comments: N open, M closed` line per PR in human output and add `codeCommentCounts` to the `--json` result. Verify T016 passes.
+- [X] T017 [US3] In `createPrStatusCommand` (`src/commands/pr.ts`): also call `getPullRequestThreads` per PR and compute `codeCommentCounts = { open, closed }` over code-anchored threads using `isThreadResolved`.
+- [X] T018 [US3] Render a `Code comments: N open, M closed` line per PR in human output and add `codeCommentCounts` to the `--json` result. Verify T016 passes.
 
 **Checkpoint**: US3 shippable — status shows comment counts.
 
@@ -93,10 +93,10 @@ Type extensions shared across stories — must land before story implementation.
 
 ## Phase 6: Polish & cross-cutting
 
-- [ ] T019 [P] Update `docs/commands.md`: document `pr status` policy-evaluation checks + `Code comments` line, and `pr comments` `--code-related-only` / `--exclude-resolved` (alias of `--hide-resolved`).
-- [ ] T020 [P] Review/update `README.md` per constitution (new flags + status output), if the PR surface is described there.
-- [ ] T021 Finalise the PR report (`specs/023-pr-comments-status/pr-report.md`) — What's New / Testing sections (done in speckit-gh step 11).
-- [ ] T022 Full gate: `npm run lint && npm test && npm run build` all green; manual quickstart spot-check from `quickstart.md` if a live PR is available.
+- [X] T019 [P] Update `docs/commands.md`: document `pr status` policy-evaluation checks + `Code comments` line, and `pr comments` `--code-related-only` / `--exclude-resolved` (alias of `--hide-resolved`).
+- [X] T020 [P] Review/update `README.md` per constitution (new flags + status output), if the PR surface is described there.
+- [X] T021 Finalise the PR report (`specs/023-pr-comments-status/pr-report.md`) — What's New / Testing sections (done in speckit-gh step 11).
+- [X] T022 Full gate: `npm run lint && npm test && npm run build` all green; manual quickstart spot-check from `quickstart.md` if a live PR is available.
 
 ---
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import type {
   ActiveCommentThread,
   BranchPullRequestMatch,
+  CodeCommentCounts,
   PullRequestCommentsResult,
   PullRequestCheck,
   PullRequestStatusPullRequest,
@@ -13,6 +14,8 @@ import {
   openPullRequest,
   getPullRequestThreads,
   getPullRequestChecks,
+  getPullRequestPolicyEvaluations,
+  resolveProjectId,
   getPullRequestById,
   isThreadResolved,
   patchThreadStatus,
@@ -27,6 +30,8 @@ interface PrCommandOptions {
   project?: string;
   json?: boolean;
   hideResolved?: boolean;
+  excludeResolved?: boolean;
+  codeRelatedOnly?: boolean;
   prNumber?: string;
 }
 
@@ -133,7 +138,12 @@ function handlePrCommandError(err: unknown, context?: AzdoContext, mode: 'read' 
   writeError(error.message);
 }
 
-function formatPullRequestChecks(checks: PullRequestCheck[]): string[] {
+function formatPullRequestChecks(checks: PullRequestCheck[], checksError?: string | null): string[] {
+  if (checksError) {
+    // A retrieval failure must never look like "no checks" (FR-002).
+    return [`Checks: unable to retrieve (${checksError})`];
+  }
+
   if (checks.length === 0) {
     return ['Checks: none reported by Azure DevOps'];
   }
@@ -149,13 +159,93 @@ function formatPullRequestChecks(checks: PullRequestCheck[]): string[] {
   return lines;
 }
 
+// Counts code-anchored (file/line) threads bucketed by resolved state. General
+// (non-file-anchored) threads are excluded from both buckets (FR-008).
+function countCodeComments(threads: ActiveCommentThread[]): CodeCommentCounts {
+  let open = 0;
+  let closed = 0;
+  for (const thread of threads) {
+    if (thread.threadContext === null) {
+      continue;
+    }
+    if (isThreadResolved(thread.status)) {
+      closed += 1;
+    } else {
+      open += 1;
+    }
+  }
+  return { open, closed };
+}
+
+function formatCodeCommentCounts(counts: CodeCommentCounts): string {
+  return `Code comments: ${counts.open} open, ${counts.closed} closed`;
+}
+
 function formatPullRequestBlock(pullRequest: PullRequestStatusPullRequest): string {
   return [
     `#${pullRequest.id} [${pullRequest.status}] ${pullRequest.title}`,
     `${formatBranchName(pullRequest.sourceRefName)} -> ${formatBranchName(pullRequest.targetRefName)}`,
     pullRequest.url ?? '—',
-    ...formatPullRequestChecks(pullRequest.checks),
+    ...formatPullRequestChecks(pullRequest.checks, pullRequest.checksError),
+    formatCodeCommentCounts(pullRequest.codeCommentCounts),
   ].join('\n');
+}
+
+// Builds one PR status entry: merges status-API checks with branch policy
+// evaluations and computes code-comment counts. Each remote fetch is isolated
+// so a single failure degrades gracefully instead of aborting the command:
+// - checks: error reported only when BOTH sources fail (FR-002);
+// - threads: a failure yields zero counts rather than hiding the PR.
+async function buildPullRequestStatusEntry(
+  context: AzdoContext,
+  repo: string,
+  cred: AuthCredential,
+  pullRequest: BranchPullRequestMatch,
+  projectId: string | null,
+): Promise<PullRequestStatusPullRequest> {
+  let statusChecks: PullRequestCheck[] = [];
+  let statusOk = true;
+  try {
+    statusChecks = await getPullRequestChecks(context, repo, cred, pullRequest.id);
+  } catch {
+    statusOk = false;
+  }
+
+  let policyChecks: PullRequestCheck[] = [];
+  // A null projectId means the GUID could not be resolved, so the policy
+  // source could not even be attempted — that counts as a policy error so an
+  // empty result is not misreported as "none".
+  let policyOk = true;
+  if (projectId === null) {
+    policyOk = false;
+  } else {
+    try {
+      policyChecks = await getPullRequestPolicyEvaluations(context, cred, projectId, pullRequest.id);
+    } catch {
+      policyOk = false;
+    }
+  }
+
+  let codeCommentCounts: CodeCommentCounts;
+  try {
+    const threads = await getPullRequestThreads(context, repo, cred, pullRequest.id);
+    codeCommentCounts = countCodeComments(threads);
+  } catch {
+    codeCommentCounts = { open: 0, closed: 0 };
+  }
+
+  const checks = [...statusChecks, ...policyChecks];
+  // Only report a retrieval failure when we have nothing to show AND a source
+  // actually failed — otherwise real (possibly partial) results are shown, and
+  // a genuine empty result still reads as "none reported" (FR-002).
+  const checksError = checks.length === 0 && (!statusOk || !policyOk) ? 'Azure DevOps request failed' : null;
+
+  return {
+    ...pullRequest,
+    checks,
+    codeCommentCounts,
+    checksError,
+  };
 }
 
 // Short user-facing label for a thread's backend status. Any state that
@@ -221,11 +311,21 @@ export function createPrStatusCommand(): Command {
         // is guaranteed non-null at runtime.
         const branch = resolved.branch!;
         const pullRequests = await listPullRequests(resolved.context, resolved.repo, resolved.pat, branch);
+
+        // The policy-evaluation artifactId needs the project GUID. Resolve it
+        // once (best-effort): if it fails, we still show status-API checks and
+        // simply skip the policy source for every PR.
+        let projectId: string | null = null;
+        try {
+          projectId = await resolveProjectId(resolved.context, resolved.pat);
+        } catch {
+          projectId = null;
+        }
+
         const pullRequestsWithChecks: PullRequestStatusPullRequest[] = await Promise.all(
-          pullRequests.map(async (pullRequest) => ({
-            ...pullRequest,
-            checks: await getPullRequestChecks(resolved.context, resolved.repo, resolved.pat, pullRequest.id),
-          })),
+          pullRequests.map(async (pullRequest) =>
+            buildPullRequestStatusEntry(resolved.context, resolved.repo, resolved.pat, pullRequest, projectId),
+          ),
         );
         const result: PullRequestStatusResult = { branch, repository: resolved.repo, pullRequests: pullRequestsWithChecks };
 
@@ -337,6 +437,8 @@ export function createPrCommentsCommand(): Command {
     .option('--project <project>', 'Azure DevOps project')
     .option('--pr-number <N>', PR_NUMBER_HELP)
     .option('--hide-resolved', 'hide threads whose status is resolved / won\'t fix / closed / by design')
+    .option('--exclude-resolved', 'alias of --hide-resolved: exclude resolved / won\'t fix / closed / by design threads')
+    .option('--code-related-only', 'show only threads anchored to a file/line; omit general discussion threads')
     .option('--json', 'output JSON')
     .action(async (options: PrCommandOptions) => {
       validateOrgProjectPair(options);
@@ -388,10 +490,18 @@ export function createPrCommentsCommand(): Command {
           branchLabel = resolved.branch!;
         }
 
+        // --exclude-resolved is an alias of --hide-resolved (owner decision on
+        // #50): either flag drops resolved threads, no behaviour change when
+        // neither is set.
+        const hideResolved = options.hideResolved === true || options.excludeResolved === true;
+        const codeRelatedOnly = options.codeRelatedOnly === true;
+
         const allThreads = await getPullRequestThreads(resolved.context, resolved.repo, resolved.pat, pullRequest.id);
-        const threads = options.hideResolved
-          ? allThreads.filter((thread) => !isThreadResolved(thread.status))
-          : allThreads;
+        const threads = allThreads.filter(
+          (thread) =>
+            (!hideResolved || !isThreadResolved(thread.status)) &&
+            (!codeRelatedOnly || thread.threadContext !== null),
+        );
         const result: PullRequestCommentsResult = { branch: branchLabel, pullRequest, threads };
 
         if (options.json) {
@@ -400,8 +510,17 @@ export function createPrCommentsCommand(): Command {
         }
 
         if (threads.length === 0) {
-          if (options.hideResolved && allThreads.length > 0) {
-            process.stdout.write(`Pull request #${pullRequest.id} has no unresolved comment threads (${allThreads.length} resolved thread${allThreads.length === 1 ? '' : 's'} hidden by --hide-resolved).\n`);
+          if (allThreads.length > 0 && (hideResolved || codeRelatedOnly)) {
+            const filters: string[] = [];
+            if (codeRelatedOnly) {
+              filters.push('code-related');
+            }
+            if (hideResolved) {
+              filters.push('unresolved');
+            }
+            process.stdout.write(
+              `Pull request #${pullRequest.id} has no ${filters.join(' ')} comment threads (filtered from ${allThreads.length} thread${allThreads.length === 1 ? '' : 's'}).\n`,
+            );
           } else {
             process.stdout.write(`Pull request #${pullRequest.id} has no comment threads.\n`);
           }

--- a/src/services/pr-client.ts
+++ b/src/services/pr-client.ts
@@ -3,8 +3,11 @@ import { authHeaders, fetchWithErrors } from './azdo-client.js';
 import type {
   ActiveCommentThread,
   ActivePullRequestComment,
+  AzdoPolicyEvaluation,
+  AzdoPolicyEvaluationListResponse,
   AzdoPrListResponse,
   AzdoPrStatusListResponse,
+  AzdoProject,
   AzdoPullRequest,
   AzdoPullRequestStatus,
   AzdoThread,
@@ -43,6 +46,25 @@ function buildPullRequestStatusesUrl(context: AzdoContext, repo: string, prId: n
     `https://dev.azure.com/${encodeURIComponent(context.org)}/${encodeURIComponent(context.project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullRequests/${prId}/statuses`,
   );
   url.searchParams.set('api-version', '7.1');
+  return url;
+}
+
+function buildProjectUrl(context: AzdoContext): URL {
+  const url = new URL(
+    `https://dev.azure.com/${encodeURIComponent(context.org)}/_apis/projects/${encodeURIComponent(context.project)}`,
+  );
+  url.searchParams.set('api-version', '7.1');
+  return url;
+}
+
+function buildPolicyEvaluationsUrl(context: AzdoContext, projectId: string, prId: number): URL {
+  const url = new URL(
+    `https://dev.azure.com/${encodeURIComponent(context.org)}/${encodeURIComponent(context.project)}/_apis/policy/evaluations`,
+  );
+  url.searchParams.set('api-version', '7.1');
+  // The PR is identified to the policy engine by a CodeReview artifact id that
+  // embeds the project GUID and the pull request id.
+  url.searchParams.set('artifactId', `vstfs:///CodeReview/CodeReviewId/${projectId}/${prId}`);
   return url;
 }
 
@@ -92,6 +114,58 @@ function mapPullRequestCheck(status: AzdoPullRequestStatus): PullRequestCheck | 
     createdBy: status.createdBy?.displayName ?? null,
     createdAt: status.creationDate ?? null,
     updatedAt: status.updatedDate ?? null,
+    source: 'status',
+  };
+}
+
+// Branch policy evaluation status values map onto the same check states the
+// status formatter already renders. `notApplicable`/`notSet` evaluations carry
+// no signal, so we drop them — mirroring mapPullRequestCheck().
+function mapPolicyEvaluationState(status: string | undefined): string | null {
+  switch (status) {
+    case 'approved':
+      return 'succeeded';
+    case 'rejected':
+      return 'failed';
+    case 'running':
+    case 'queued':
+      return 'pending';
+    case 'notApplicable':
+    case 'notSet':
+    case undefined:
+      return null;
+    default:
+      // Unknown future states pass through verbatim so we never hide a check.
+      return status;
+  }
+}
+
+function mapPolicyEvaluationName(evaluation: AzdoPolicyEvaluation): string {
+  const display =
+    evaluation.configuration?.settings?.displayName?.trim() ||
+    evaluation.configuration?.type?.displayName?.trim();
+  if (display) {
+    return display;
+  }
+  return `Policy ${evaluation.configuration?.id ?? evaluation.evaluationId ?? '?'}`;
+}
+
+function mapPolicyEvaluationCheck(evaluation: AzdoPolicyEvaluation): PullRequestCheck | null {
+  const state = mapPolicyEvaluationState(evaluation.status);
+  if (state === null) {
+    return null;
+  }
+
+  return {
+    id: evaluation.configuration?.id ?? 0,
+    state,
+    name: mapPolicyEvaluationName(evaluation),
+    description: null,
+    targetUrl: null,
+    createdBy: null,
+    createdAt: null,
+    updatedAt: null,
+    source: 'policy',
   };
 }
 
@@ -244,6 +318,38 @@ export async function getPullRequestChecks(
 
   return data.value
     .map(mapPullRequestCheck)
+    .filter((check): check is PullRequestCheck => check !== null);
+}
+
+// Resolves the project GUID for the current context. Needed to build the
+// policy-evaluation artifactId, since the PR/context only carry the project
+// name. Callers should resolve once and reuse for the duration of a command.
+export async function resolveProjectId(context: AzdoContext, cred: AuthCredential): Promise<string> {
+  const response = await fetchWithErrors(buildProjectUrl(context).toString(), {
+    headers: authHeaders(cred),
+  });
+  const data = await readJsonResponse<AzdoProject>(response);
+  return data.id;
+}
+
+// Fetches branch policy evaluations for a PR and maps them to checks. These are
+// the build-validation / required-reviewer "checks" the Azure DevOps UI shows;
+// they are NOT returned by the statuses endpoint, which is why `pr status`
+// merges both sources.
+export async function getPullRequestPolicyEvaluations(
+  context: AzdoContext,
+  cred: AuthCredential,
+  projectId: string,
+  prId: number,
+): Promise<PullRequestCheck[]> {
+  const response = await fetchWithErrors(
+    buildPolicyEvaluationsUrl(context, projectId, prId).toString(),
+    { headers: authHeaders(cred) },
+  );
+  const data = await readJsonResponse<AzdoPolicyEvaluationListResponse>(response);
+
+  return data.value
+    .map(mapPolicyEvaluationCheck)
     .filter((check): check is PullRequestCheck => check !== null);
 }
 

--- a/src/types/pull-request.ts
+++ b/src/types/pull-request.ts
@@ -18,10 +18,26 @@ export interface PullRequestCheck {
   createdBy: string | null;
   createdAt: string | null;
   updatedAt: string | null;
+  // Where this check came from: the Pull Request Status API (`status`) or a
+  // branch policy evaluation (`policy`). Branch-policy build validations are
+  // the green checks the Azure DevOps UI shows; they are NOT returned by the
+  // statuses endpoint, so both sources are merged for `pr status`.
+  source?: 'status' | 'policy';
+}
+
+// Open/closed counts of code-anchored (file/line) comment threads on a PR.
+// General (non-file-anchored) threads are excluded.
+export interface CodeCommentCounts {
+  open: number;
+  closed: number;
 }
 
 export interface PullRequestStatusPullRequest extends BranchPullRequestMatch {
   checks: PullRequestCheck[];
+  codeCommentCounts: CodeCommentCounts;
+  // Set when check retrieval failed entirely (both the status and policy
+  // sources errored), so "none reported" is never shown for a fetch failure.
+  checksError?: string | null;
 }
 
 export interface PullRequestStatusResult {
@@ -139,4 +155,35 @@ export interface AzdoPullRequestStatus {
   creationDate?: string;
   updatedDate?: string;
   targetUrl?: string;
+}
+
+// Minimal shape of the Projects API response — we only need the GUID to build
+// the policy-evaluation artifactId.
+export interface AzdoProject {
+  id: string;
+  name?: string;
+}
+
+export interface AzdoPolicyEvaluationListResponse {
+  value: AzdoPolicyEvaluation[];
+  count?: number;
+}
+
+// Branch policy evaluation as returned by
+// GET .../_apis/policy/evaluations?artifactId=...
+// `status` ∈ {approved, rejected, running, queued, notApplicable, notSet, ...}.
+export interface AzdoPolicyEvaluation {
+  evaluationId?: string;
+  status?: string;
+  configuration?: {
+    id?: number;
+    isBlocking?: boolean;
+    type?: {
+      id?: string;
+      displayName?: string;
+    };
+    settings?: {
+      displayName?: string;
+    };
+  };
 }

--- a/tests/unit/pr-client.test.ts
+++ b/tests/unit/pr-client.test.ts
@@ -3,11 +3,13 @@ import type { AzdoContext } from '../../src/types/work-item.js';
 import {
   getPullRequestById,
   getPullRequestChecks,
+  getPullRequestPolicyEvaluations,
   getPullRequestThreads,
   isThreadResolved,
   listPullRequests,
   openPullRequest,
   patchThreadStatus,
+  resolveProjectId,
 } from '../../src/services/pr-client.js';
 
 const context: AzdoContext = { org: 'test-org', project: 'test-project' };
@@ -455,6 +457,7 @@ describe('pr-client', () => {
           createdBy: 'Azure Pipelines',
           createdAt: '2026-03-31T10:00:00Z',
           updatedAt: '2026-03-31T10:05:00Z',
+          source: 'status',
         },
         {
           id: 2,
@@ -465,6 +468,7 @@ describe('pr-client', () => {
           createdBy: null,
           createdAt: '2026-03-31T10:01:00Z',
           updatedAt: '2026-03-31T10:06:00Z',
+          source: 'status',
         },
         {
           id: 3,
@@ -475,6 +479,7 @@ describe('pr-client', () => {
           createdBy: null,
           createdAt: '2026-03-31T10:02:00Z',
           updatedAt: '2026-03-31T10:07:00Z',
+          source: 'status',
         },
       ]);
     });
@@ -486,6 +491,57 @@ describe('pr-client', () => {
       } as Response);
 
       await expect(getPullRequestChecks(context, 'repo-name', 'pat', 12)).rejects.toThrow('AUTH_FAILED');
+    });
+  });
+
+  describe('resolveProjectId', () => {
+    it('returns the project GUID from the Projects API', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'abc-123-guid', name: 'test-project' }),
+      } as Response);
+
+      const id = await resolveProjectId(context, 'pat');
+      expect(id).toBe('abc-123-guid');
+      expect(fetchSpy.mock.calls[0][0]).toContain('/_apis/projects/test-project');
+    });
+  });
+
+  describe('getPullRequestPolicyEvaluations', () => {
+    it('maps policy evaluations to checks and normalises their state', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          value: [
+            {
+              evaluationId: 'e1',
+              status: 'approved',
+              configuration: { id: 10, type: { displayName: 'Build' }, settings: { displayName: 'Build validation' } },
+            },
+            { evaluationId: 'e2', status: 'rejected', configuration: { id: 11, type: { displayName: 'Required reviewers' } } },
+            { evaluationId: 'e3', status: 'running', configuration: { id: 12, type: { displayName: 'Status' } } },
+            { evaluationId: 'e4', status: 'queued', configuration: { id: 13, type: { displayName: 'Queued policy' } } },
+            // dropped — no signal
+            { evaluationId: 'e5', status: 'notApplicable', configuration: { id: 14, type: { displayName: 'N/A' } } },
+            { evaluationId: 'e6', status: 'notSet', configuration: { id: 15, type: { displayName: 'Not set' } } },
+          ],
+        }),
+      } as Response);
+
+      const result = await getPullRequestPolicyEvaluations(context, 'pat', 'proj-guid', 12);
+
+      // build artifactId carries project GUID + PR id
+      expect(fetchSpy.mock.calls[0][0]).toContain(
+        'artifactId=vstfs%3A%2F%2F%2FCodeReview%2FCodeReviewId%2Fproj-guid%2F12',
+      );
+      expect(result).toEqual([
+        { id: 10, state: 'succeeded', name: 'Build validation', description: null, targetUrl: null, createdBy: null, createdAt: null, updatedAt: null, source: 'policy' },
+        { id: 11, state: 'failed', name: 'Required reviewers', description: null, targetUrl: null, createdBy: null, createdAt: null, updatedAt: null, source: 'policy' },
+        { id: 12, state: 'pending', name: 'Status', description: null, targetUrl: null, createdBy: null, createdAt: null, updatedAt: null, source: 'policy' },
+        { id: 13, state: 'pending', name: 'Queued policy', description: null, targetUrl: null, createdBy: null, createdAt: null, updatedAt: null, source: 'policy' },
+      ]);
     });
   });
 

--- a/tests/unit/pr-comments-filters.test.ts
+++ b/tests/unit/pr-comments-filters.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPrCommentsCommand } from '../../src/commands/pr.js';
+import { createCommandRunner, getStdout, setupProcessSpies } from './helpers/command-test-utils.js';
+
+vi.mock('../../src/services/pr-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/pr-client.js')>();
+  return {
+    ...actual,
+    listPullRequests: vi.fn(),
+    getPullRequestThreads: vi.fn(),
+    getPullRequestById: vi.fn(),
+  };
+});
+
+vi.mock('../../src/services/git-remote.js', () => ({
+  detectRepoName: vi.fn(),
+  getCurrentBranch: vi.fn(),
+}));
+
+vi.mock('../../src/services/auth.js', () => ({
+  requireAuthCredential: vi.fn(),
+}));
+
+vi.mock('../../src/services/context.js', () => ({
+  resolveContext: vi.fn(),
+}));
+
+import { getPullRequestThreads, listPullRequests } from '../../src/services/pr-client.js';
+import { detectRepoName, getCurrentBranch } from '../../src/services/git-remote.js';
+import { requireAuthCredential } from '../../src/services/auth.js';
+import { resolveContext } from '../../src/services/context.js';
+
+const run = createCommandRunner(createPrCommentsCommand);
+
+const basePullRequest = {
+  id: 12,
+  title: 'Test PR',
+  repository: 'repo-name',
+  sourceRefName: 'refs/heads/feature/test',
+  targetRefName: 'refs/heads/develop',
+  status: 'active',
+  createdBy: 'Alice',
+  url: 'https://example.test/pr/12',
+} as const;
+
+function comment(content: string) {
+  return { id: 1, author: 'Alice', content, publishedAt: null };
+}
+
+// A representative mixed set: code-anchored vs general, resolved vs active.
+const codeActive = {
+  id: 1,
+  status: 'active',
+  threadContext: 'src/app.ts',
+  comments: [comment('please rename this')],
+};
+const codeResolved = {
+  id: 2,
+  status: 'fixed',
+  threadContext: 'src/util.ts',
+  comments: [comment('fixed already')],
+};
+const generalActive = {
+  id: 3,
+  status: 'active',
+  threadContext: null,
+  comments: [comment('overall LGTM discussion')],
+};
+const generalResolved = {
+  id: 4,
+  status: 'closed',
+  threadContext: null,
+  comments: [comment('closed discussion')],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupProcessSpies();
+  vi.mocked(resolveContext).mockReturnValue({ org: 'test-org', project: 'test-project' });
+  vi.mocked(requireAuthCredential).mockResolvedValue({ pat: 'test-pat', source: 'env', kind: 'pat' });
+  vi.mocked(detectRepoName).mockReturnValue('repo-name');
+  vi.mocked(getCurrentBranch).mockReturnValue('feature/test');
+  vi.mocked(listPullRequests).mockResolvedValue([basePullRequest]);
+  vi.mocked(getPullRequestThreads).mockResolvedValue([
+    codeActive,
+    codeResolved,
+    generalActive,
+    generalResolved,
+  ]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function threadIdsFromJson(): number[] {
+  return JSON.parse(getStdout()).threads.map((t: { id: number }) => t.id);
+}
+
+describe('pr comments filters (#50)', () => {
+  it('no new flags: shows all threads (regression / no behaviour change)', async () => {
+    await run(['--json']);
+    expect(threadIdsFromJson()).toEqual([1, 2, 3, 4]);
+  });
+
+  it('--code-related-only: keeps only file-anchored threads', async () => {
+    await run(['--code-related-only', '--json']);
+    expect(threadIdsFromJson()).toEqual([1, 2]);
+  });
+
+  it('--exclude-resolved: drops resolved threads', async () => {
+    await run(['--exclude-resolved', '--json']);
+    expect(threadIdsFromJson()).toEqual([1, 3]);
+  });
+
+  it('--hide-resolved yields the same set as --exclude-resolved (alias)', async () => {
+    // --exclude-resolved is asserted to yield [1, 3] above; --hide-resolved
+    // must produce the identical filtered set.
+    await run(['--hide-resolved', '--json']);
+    expect(threadIdsFromJson()).toEqual([1, 3]);
+  });
+
+  it('combined --code-related-only --exclude-resolved: only unresolved code threads', async () => {
+    await run(['--code-related-only', '--exclude-resolved', '--json']);
+    expect(threadIdsFromJson()).toEqual([1]);
+  });
+
+  it('prints an informative message when filters remove everything', async () => {
+    vi.mocked(getPullRequestThreads).mockResolvedValue([generalResolved]);
+    await run(['--code-related-only', '--exclude-resolved']);
+    const out = getStdout();
+    expect(out).toContain('no code-related unresolved comment threads');
+    expect(out).toContain('filtered from 1 thread');
+  });
+});

--- a/tests/unit/pr-status.test.ts
+++ b/tests/unit/pr-status.test.ts
@@ -5,6 +5,11 @@ import { createCommandRunner, getExitCode, getStderr, getStdout, setupProcessSpi
 vi.mock('../../src/services/pr-client.js', () => ({
   listPullRequests: vi.fn(),
   getPullRequestChecks: vi.fn(),
+  getPullRequestPolicyEvaluations: vi.fn(),
+  resolveProjectId: vi.fn(),
+  getPullRequestThreads: vi.fn(),
+  isThreadResolved: (status: string) =>
+    new Set(['fixed', 'wontFix', 'closed', 'byDesign']).has(status),
 }));
 
 vi.mock('../../src/services/git-remote.js', () => ({
@@ -20,7 +25,13 @@ vi.mock('../../src/services/context.js', () => ({
   resolveContext: vi.fn(),
 }));
 
-import { getPullRequestChecks, listPullRequests } from '../../src/services/pr-client.js';
+import {
+  getPullRequestChecks,
+  getPullRequestPolicyEvaluations,
+  getPullRequestThreads,
+  listPullRequests,
+  resolveProjectId,
+} from '../../src/services/pr-client.js';
 import { detectRepoName, getCurrentBranch } from '../../src/services/git-remote.js';
 import { requireAuthCredential } from '../../src/services/auth.js';
 import { resolveContext } from '../../src/services/context.js';
@@ -68,6 +79,9 @@ beforeEach(() => {
   vi.mocked(getCurrentBranch).mockReturnValue('feature/test');
   vi.mocked(listPullRequests).mockResolvedValue([]);
   vi.mocked(getPullRequestChecks).mockResolvedValue([]);
+  vi.mocked(resolveProjectId).mockResolvedValue('project-guid');
+  vi.mocked(getPullRequestPolicyEvaluations).mockResolvedValue([]);
+  vi.mocked(getPullRequestThreads).mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -153,6 +167,8 @@ describe('pr status command', () => {
         {
           ...pullRequest,
           checks: [makeCheck()],
+          codeCommentCounts: { open: 0, closed: 0 },
+          checksError: null,
         },
       ],
     });
@@ -165,14 +181,18 @@ describe('pr status command', () => {
     expect(getExitCode()).toBe(1);
   });
 
-  it('fails when Azure DevOps check lookup fails', async () => {
+  it('reports checks as unavailable (not "none") when both check sources fail, without aborting', async () => {
     vi.mocked(listPullRequests).mockResolvedValue([makePullRequest({ title: 'Test PR', status: 'active' })]);
     vi.mocked(getPullRequestChecks).mockRejectedValue(new Error('HTTP_500'));
+    vi.mocked(getPullRequestPolicyEvaluations).mockRejectedValue(new Error('HTTP_500'));
 
     await run([]);
 
-    expect(getStderr()).toContain('Azure DevOps request failed with HTTP_500.');
-    expect(getExitCode()).toBe(1);
+    const output = getStdout();
+    expect(output).toContain('#12 [active] Test PR');
+    expect(output).toContain('Checks: unable to retrieve');
+    expect(output).not.toContain('none reported');
+    expect(getExitCode()).toBe(0);
   });
 
   it('prints a detached HEAD error and exits with code 1', async () => {
@@ -182,5 +202,57 @@ describe('pr status command', () => {
     await run([]);
     expect(getStderr()).toContain('Not on a named branch. Check out a named branch and try again.');
     expect(getExitCode()).toBe(1);
+  });
+
+  // US1 — merge branch policy evaluations with status-API checks (#50)
+  it('lists branch policy evaluation checks alongside status checks', async () => {
+    vi.mocked(listPullRequests).mockResolvedValue([makePullRequest({ title: 'Test PR', status: 'active' })]);
+    vi.mocked(getPullRequestChecks).mockResolvedValue([]);
+    vi.mocked(getPullRequestPolicyEvaluations).mockResolvedValue([
+      {
+        id: 10,
+        state: 'succeeded',
+        name: 'Build validation',
+        description: null,
+        targetUrl: null,
+        createdBy: null,
+        createdAt: null,
+        updatedAt: null,
+        source: 'policy',
+      },
+    ]);
+
+    await run([]);
+
+    const output = getStdout();
+    expect(output).toContain('Checks:');
+    expect(output).toContain('- [succeeded] Build validation');
+    expect(output).not.toContain('none reported');
+  });
+
+  // US3 — open/closed code-comment counts (#50)
+  it('prints open/closed counts of code-anchored comments, excluding general threads', async () => {
+    vi.mocked(listPullRequests).mockResolvedValue([makePullRequest({ title: 'Test PR', status: 'active' })]);
+    vi.mocked(getPullRequestThreads).mockResolvedValue([
+      { id: 1, status: 'active', threadContext: 'src/a.ts', comments: [] },
+      { id: 2, status: 'active', threadContext: 'src/b.ts', comments: [] },
+      { id: 3, status: 'fixed', threadContext: 'src/c.ts', comments: [] },
+      { id: 4, status: 'active', threadContext: null, comments: [] }, // general — excluded
+    ]);
+
+    await run([]);
+
+    expect(getStdout()).toContain('Code comments: 2 open, 1 closed');
+  });
+
+  it('reports zero code-comment counts when there are no code-anchored threads', async () => {
+    vi.mocked(listPullRequests).mockResolvedValue([makePullRequest({ title: 'Test PR', status: 'active' })]);
+    vi.mocked(getPullRequestThreads).mockResolvedValue([
+      { id: 4, status: 'active', threadContext: null, comments: [] },
+    ]);
+
+    await run([]);
+
+    expect(getStdout()).toContain('Code comments: 0 open, 0 closed');
   });
 });


### PR DESCRIPTION
# PR Report: Better support for commenting in the pull request

**Branch**: `023-pr-comments-status`
**Date**: 2026-06-03
**Spec**: [specs/023-pr-comments-status/spec.md](./spec.md)

## Summary

Improves the `azdo pr status` and `azdo pr comments` commands. Fixes a defect
where `pr status` reported "no checks" even when green branch-policy checks
were running, adds two opt-in filters to `pr comments` for triaging review
feedback, and surfaces open/closed code-comment counts in `pr status`.
Closes #50.

## What's New

- **`pr status` — checks now include branch policy evaluations**: the command
  previously read only the Pull Request *Status API*, which does not return
  branch-policy results (build validation, required reviewers, …) — the green
  checks shown in the Azure DevOps UI. It now also fetches **policy
  evaluations** (resolving the project GUID via the Projects API) and shows the
  merged set. Each check carries a `source` of `status` or `policy` in `--json`.
- **`pr status` — honest empty-vs-error**: `Checks: none reported by Azure
  DevOps` is shown only when both sources are genuinely empty. A retrieval
  failure now shows `Checks: unable to retrieve (…)` instead of silently
  reading as "none", and a check-fetch failure no longer aborts the whole
  command.
- **`pr status` — code-comment counts**: a new `Code comments: N open, M
  closed` line counts only code-anchored (file/line) threads; general
  discussion threads are excluded. Exposed as `codeCommentCounts` in `--json`.
- **`pr comments` — `--code-related-only`**: shows only threads anchored to a
  real file/line.
- **`pr comments` — `--exclude-resolved`**: alias of the existing
  `--hide-resolved`; either flag drops resolved/won't-fix/closed/by-design
  threads. The two filters are independent and combinable; with neither flag,
  output is unchanged.
- **Docs**: `docs/commands.md` and `README.md` updated for the new flags and
  status output.

## Breaking Changes

- **`pr status` no longer exits non-zero when the check lookup fails.**
  Previously a failed checks fetch aborted the command with exit 1. It now
  degrades gracefully: the PR is still listed and the checks line reads
  `unable to retrieve (…)`. This is intentional (FR-002) — a transient checks
  failure should not hide the PR, and "no checks" must never mask an error.

## Testing

- **Unit (vitest)**:
  - `pr-client.test.ts`: policy-evaluation → check mapping with state
    normalisation (approved→succeeded, rejected→failed, running/queued→pending,
    notApplicable/notSet dropped), artifactId construction, and
    `resolveProjectId`; existing status checks now assert `source: 'status'`.
  - `pr-status.test.ts`: merged policy+status checks displayed; empty-vs-error
    (`unable to retrieve`, no abort); open/closed code-comment counts incl.
    general-thread exclusion and the zero case; updated `--json` shape.
  - `pr-comments-filters.test.ts`: `--code-related-only`, `--exclude-resolved`
    (≡ `--hide-resolved`), combination, the no-flag regression, and the
    filtered-to-empty message.
- **Gate**: `npm run lint` clean, `npx tsc --noEmit` clean, `npm test` =
  768 passed / 7 pre-existing skips, `npm run build` clean.

## Notes

- `npm run format` (prettier `--check`) reports pre-existing style warnings
  across ~41 unrelated `src/` files; the repo baseline is not prettier-clean
  and `format` is not part of the lint/test/build gate, so no unrelated
  reformatting was done.
- The live `quickstart.md` spot-check requires a real Azure DevOps PR with a
  green build-validation policy; it is provided for manual verification and was
  not run in CI (no live ADO credentials in the test environment).
