### PR TITLE
feat(#61): pr comments visualize filename and line number

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ bd close <id>         # Complete work
 - TypeScript 5.x (`strict: true`) on Node.js LTS (18+) + commander.js (CLI), native `fetch` (HTTP), `node:child_process` execSync (git), `node:fs`/`node:path`/`node:os` (config I/O) — all existing; **no new dependencies** (025-multi-org-support)
 - JSON file at `~/.azdo/config.json` (existing; extended with an `organizations` map) (025-multi-org-support)
 - TypeScript 5.x (strict mode), Node.js LTS + commander.js (CLI), native `fetch` (HTTP) — no new deps (027-work-item-relations)
+- TypeScript 5.x (strict: true) + commander.js (CLI framework), native `fetch` (HTTP), vitest (tests) (028-pr-comment-line)
 
 ## Recent Changes
 - 019-fix-pr-command: `azdo pr` now recognises HTTPS remotes with a `<user>[:<token>]@` userinfo prefix and an optional `.git` suffix (one-time, sanitised stderr credential warning; host allow-list unchanged). The single-PR commands (`pr comments` / `comment-resolve` / `comment-reopen`) document the branch→PR auto-detection rule in `--help` and fail cleanly on zero/multi-match; `pr status` stays a multi-PR list (decision A). No new runtime deps.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ azdo comments list 12345
 azdo comments add 12345 "Investigating the root cause now."
 
 # PR comment threads — list, filter, target by number, resolve or reopen
-azdo pr comments                        # active-branch PR
+azdo pr comments                        # active-branch PR; code-anchored threads show file:line
 azdo pr comments --pr-number 64         # any PR by number (skips branch lookup)
 azdo pr comments --pr-number 64 --hide-resolved      # or --exclude-resolved (alias)
 azdo pr comments --code-related-only    # only file/line-anchored threads

--- a/specs/028-pr-comment-line/checklists/requirements.md
+++ b/specs/028-pr-comment-line/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: PR Comment Line Number Display
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/028-pr-comment-line/contracts/cli-commands.md
+++ b/specs/028-pr-comment-line/contracts/cli-commands.md
@@ -1,0 +1,89 @@
+# CLI Contract: 028-pr-comment-line (issue #61)
+
+Defines the observable command surface after this feature. Existing options
+and all other commands are unchanged.
+
+---
+
+## `azdo pr comments`
+
+### Options (all unchanged)
+
+`--org`, `--project`, `--pr-number <N>`, `--json`,
+`--hide-resolved`, `--exclude-resolved`, `--code-related-only`
+
+### Behaviour changes
+
+**Thread header line (FR-001, FR-002, FR-003).**
+For code-anchored threads, the header line gains a `:N` suffix when a line
+position is available from the API:
+
+```
+Thread #<id> [<status>] <filePath>:<line>
+```
+
+When no line position is available:
+
+```
+Thread #<id> [<status>] <filePath>
+```
+
+General threads (no file anchor) are byte-for-byte unchanged:
+
+```
+Thread #<id> [<status>] (general)
+```
+
+### Human output (example, with line data present)
+
+```
+Comment threads for pull request #4674: My PR title
+
+Thread #69293 [active] /src/Intranet/Search/OmniSearchIndexerPipeline.cs:42
+  Gian Maria Ricci: Should we cache this result?
+
+Thread #69294 [resolved] /src/Shared/Utils.cs:17
+  Alice: Fixed in the last commit.
+```
+
+### JSON output (`--json`) — additive
+
+Each thread object gains a `line` field. All existing fields are preserved.
+
+```jsonc
+{
+  "branch": "feature/x",
+  "pullRequest": { /* unchanged */ },
+  "threads": [
+    {
+      "id": 69293,
+      "status": "active",
+      "threadContext": "/src/Intranet/Search/OmniSearchIndexerPipeline.cs",
+      "line": 42,          // NEW — positive integer or null
+      "comments": [ /* unchanged */ ]
+    },
+    {
+      "id": 69294,
+      "status": "active",
+      "threadContext": null,   // general thread
+      "line": null,            // NEW — always null for general threads
+      "comments": [ /* unchanged */ ]
+    }
+  ]
+}
+```
+
+### Backward compatibility
+
+- **Default (no flags)**: output is identical to the prior release for any PR
+  where the ADO API does not return position data. For PRs that do, the only
+  difference is the `:N` suffix on code-anchored thread headers.
+- **`--json` consumers**: the `line` field is additive. Consumers that do not
+  read `line` are unaffected. `threadContext` remains a `string | null`.
+
+### Non-goals (explicit)
+
+- No change to `pr status`, `pr comment-resolve`, `pr comment-reopen`, or any
+  other command.
+- Column (`offset`) is not exposed.
+- No new flags added in this feature.

--- a/specs/028-pr-comment-line/data-model.md
+++ b/specs/028-pr-comment-line/data-model.md
@@ -1,0 +1,147 @@
+# Data Model: PR Comment Line Number Display
+
+**Branch**: `028-pr-comment-line` | **Date**: 2026-06-10
+
+## Modified Entities
+
+### 1. `AzdoThread` (in `src/types/pull-request.ts`)
+
+Raw ADO API response shape. Expand `threadContext` to expose position fields
+the endpoint already returns.
+
+**Before**:
+```typescript
+export interface AzdoThread {
+  id: number;
+  status?: string;
+  threadContext?: {
+    filePath?: string;
+  };
+  comments: AzdoComment[];
+}
+```
+
+**After** (additive — no existing field removed):
+```typescript
+interface CommentPosition {
+  line: number;
+  offset: number;
+}
+
+export interface AzdoThread {
+  id: number;
+  status?: string;
+  threadContext?: {
+    filePath?: string;
+    rightFileStart?: CommentPosition;
+    rightFileEnd?: CommentPosition;
+    leftFileStart?: CommentPosition;
+    leftFileEnd?: CommentPosition;
+  };
+  comments: AzdoComment[];
+}
+```
+
+`CommentPosition` can be a local interface in `pull-request.ts` (not exported —
+it is an ADO API detail, not part of the CLI's public contract).
+
+---
+
+### 2. `ActiveCommentThread` (in `src/types/pull-request.ts`)
+
+Internal mapped shape used throughout commands, services, and tests. Gains a
+`line` field.
+
+**Before**:
+```typescript
+export interface ActiveCommentThread {
+  id: number;
+  status: string;
+  threadContext: string | null;   // file path, or null for general threads
+  comments: ActivePullRequestComment[];
+}
+```
+
+**After** (additive):
+```typescript
+export interface ActiveCommentThread {
+  id: number;
+  status: string;
+  threadContext: string | null;   // file path, or null for general threads
+  line: number | null;            // line number from rightFileStart (or leftFileStart fallback)
+  comments: ActivePullRequestComment[];
+}
+```
+
+**Invariants**:
+- `line` is always a positive integer or `null` (never 0 or negative).
+- `line` is `null` when `threadContext` is `null` (general thread).
+- `line` may be `null` even when `threadContext` is non-null (file known but
+  no position in the API response).
+
+---
+
+## Mapping Logic (in `src/services/pr-client.ts`)
+
+The `mapThread` and `toActiveCommentThread` functions both apply the same
+extraction:
+
+```typescript
+const line =
+  thread.threadContext?.rightFileStart?.line ??
+  thread.threadContext?.leftFileStart?.line ??
+  null;
+```
+
+This is a pure data extraction — no new API call, no conditional branching on
+status or file type.
+
+---
+
+## Output Representation
+
+### Human-readable (`formatThreads` in `src/commands/pr.ts`)
+
+```typescript
+// Before
+`Thread #${thread.id} [${label}] ${thread.threadContext ?? '(general)'}`
+
+// After
+const location = thread.threadContext
+  ? `${thread.threadContext}${thread.line !== null ? `:${thread.line}` : ''}`
+  : '(general)';
+`Thread #${thread.id} [${label}] ${location}`
+```
+
+Examples:
+- Code-anchored with line: `Thread #69293 [active] /src/foo.ts:42`
+- Code-anchored, no line:  `Thread #69293 [active] /src/foo.ts`
+- General thread:          `Thread #69293 [active] (general)`
+
+### JSON (`--json` output in `azdo pr comments`)
+
+The `line` field is included automatically because `ActiveCommentThread` now
+carries it and the JSON serializer outputs all fields. No formatter change
+needed for JSON.
+
+Example thread object:
+```json
+{
+  "id": 69293,
+  "status": "active",
+  "threadContext": "/src/foo.ts",
+  "line": 42,
+  "comments": [...]
+}
+```
+
+General thread:
+```json
+{
+  "id": 69294,
+  "status": "active",
+  "threadContext": null,
+  "line": null,
+  "comments": [...]
+}
+```

--- a/specs/028-pr-comment-line/plan.md
+++ b/specs/028-pr-comment-line/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: PR Comment Line Number Display
+
+**Branch**: `028-pr-comment-line` | **Date**: 2026-06-10 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/028-pr-comment-line/spec.md`
+
+## Summary
+
+Add line-number display to `azdo pr comments`: each code-anchored thread header
+gains a `:N` suffix in human-readable output, and the `--json` output gains a
+`line: number | null` field per thread. The ADO threads endpoint already returns
+`threadContext.rightFileStart` / `leftFileStart` with `{ line, offset }` — the
+CLI currently discards them during mapping. The fix is purely in the type layer
+and mapper, with no new API call.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict: true)
+**Primary Dependencies**: commander.js (CLI framework), native `fetch` (HTTP), vitest (tests)
+**Storage**: N/A
+**Testing**: vitest — `npm test`
+**Target Platform**: Node.js LTS, npm distribution
+**Project Type**: CLI tool
+**Performance Goals**: N/A — purely a data-mapping change, no latency impact
+**Constraints**: Zero new runtime dependencies; `npm run lint && npm test && npm run build` must pass
+**Scale/Scope**: Touches 2 source files, 2–3 test files; no new commands
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First | ✅ Pass | Modifies existing `azdo pr comments` command; both human and `--json` output updated |
+| II. TypeScript Strictness | ✅ Pass | New field is `number \| null` — no `any`, no type suppressions |
+| III. Single Responsibility | ✅ Pass | Only `pr comments` output is touched; no other command affected |
+| IV. npm Distribution | ✅ Pass | No new dependencies; bundler unchanged |
+| V. Simplicity | ✅ Pass | Minimal change: expand ADO type + update mapper + update formatter |
+| VI. ADO API Research | ✅ Pass | Validated against Microsoft Learn and Context7 — `rightFileStart`/`leftFileStart` confirmed in API response |
+
+No violations. Complexity Tracking section not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/028-pr-comment-line/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+├── contracts/
+│   └── cli-commands.md  ← Phase 1 output
+└── tasks.md             ← /speckit-tasks output (not yet created)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── types/
+│   └── pull-request.ts         ← expand AzdoThread.threadContext; add line to ActiveCommentThread
+├── services/
+│   └── pr-client.ts            ← update mapThread() and toActiveCommentThread()
+└── commands/
+    └── pr.ts                   ← update formatThreads() to append :N
+
+tests/unit/
+├── pr-client.test.ts           ← add line-extraction test cases; update existing fixtures
+├── pr-comments.test.ts         ← update existing fixtures; add :N in output assertions
+└── pr-comments-filters.test.ts ← update existing fixtures (add line: null)
+```
+
+**Structure Decision**: Single-project layout. All touched files already exist in this structure.

--- a/specs/028-pr-comment-line/pr-report.md
+++ b/specs/028-pr-comment-line/pr-report.md
@@ -1,0 +1,31 @@
+# PR Report: PR Comment Line Number Display
+
+**Branch**: `028-pr-comment-line`
+**Date**: 2026-06-10
+**Spec**: [specs/028-pr-comment-line/spec.md](specs/028-pr-comment-line/spec.md)
+
+## Summary
+
+`azdo pr comments` now displays the line number alongside the file path for each code-anchored comment thread (e.g. `/src/foo.ts:42`). The Azure DevOps threads endpoint has always returned `rightFileStart`/`leftFileStart` position data inside `threadContext`; the CLI was discarding it. This PR expands the type layer to capture those fields, extracts the line number during mapping, and surfaces it in both human-readable and `--json` output.
+
+## What's New
+
+- **`src/types/pull-request.ts` — ADO type expansion**: Added `CommentPosition` interface; expanded `AzdoThread.threadContext` to include `rightFileStart`, `rightFileEnd`, `leftFileStart`, `leftFileEnd` position fields that the API already returns.
+- **`src/types/pull-request.ts` — internal model**: `ActiveCommentThread` gains `line: number | null` — positive integer when a line position is known, `null` for general threads or when the API provides no position.
+- **`src/services/pr-client.ts` — mapper**: `mapThread()` and `toActiveCommentThread()` now extract `line` from `rightFileStart.line` (primary) with `leftFileStart.line` as fallback.
+- **`src/commands/pr.ts` — formatter**: `formatThreads()` appends `:<line>` after the file path when `line` is non-null. General threads and threads without position data are unchanged.
+- **`--json` output**: `line` field added to each thread object automatically; `threadContext` remains a `string | null` for backward compatibility.
+
+## Testing
+
+- **Unit — mapper**: 4 new test cases in `tests/unit/pr-client.test.ts` covering right-side line, left-side fallback, file-only (no position), and general thread.
+- **Unit — formatter**: assertions in `tests/unit/pr-comments.test.ts` verify `:N` suffix present when `line` is known, absent when null, and `(general)` unchanged.
+- **Unit — JSON**: assertion verifies `line` field present in serialised output for both code-anchored and general threads.
+- **Regression**: existing fixtures in `pr-comments-filters.test.ts`, `pr-comment-state.test.ts`, `pr-status.test.ts` updated with `line: null` — all existing behaviour preserved.
+
+## Notes
+
+- `offset` (column) is intentionally not exposed; only `line` is shown.
+- No new runtime dependencies added.
+
+Closes #61

--- a/specs/028-pr-comment-line/quickstart.md
+++ b/specs/028-pr-comment-line/quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart: PR Comment Line Number Display
+
+**Branch**: `028-pr-comment-line` | **Date**: 2026-06-10
+
+## What changed (one paragraph)
+
+The `azdo pr comments` command now displays the line number for each
+code-anchored comment thread. The ADO PR threads API has always returned
+`rightFileStart` and `leftFileStart` position objects inside `threadContext`
+— the CLI was simply discarding them. This feature expands the `AzdoThread`
+type to capture those fields, extracts the line number in the mapper, adds a
+`line: number | null` field to `ActiveCommentThread`, and updates the
+human-readable formatter to append `:N` after the file path. The `--json`
+output gains `line` automatically.
+
+## Files to touch (in order)
+
+| File | Change |
+|------|--------|
+| `src/types/pull-request.ts` | Add `CommentPosition` interface; expand `AzdoThread.threadContext`; add `line: number \| null` to `ActiveCommentThread` |
+| `src/services/pr-client.ts` | Extract `line` in `mapThread()` and `toActiveCommentThread()` |
+| `src/commands/pr.ts` | Update `formatThreads()` to append `:N` when `thread.line !== null` |
+| `tests/unit/pr-client.test.ts` | Add 4 new test cases; update existing `ActiveCommentThread` fixtures to include `line: null` |
+| `tests/unit/pr-comments.test.ts` | Update fixtures; add `:N` assertions where applicable |
+| `tests/unit/pr-comments-filters.test.ts` | Update fixtures to include `line: null` |
+
+## Step-by-step implementation
+
+### Step 1 — `src/types/pull-request.ts`
+
+1. Add `CommentPosition` interface (not exported) just before `AzdoThread`.
+2. Expand `AzdoThread.threadContext` optional fields to include
+   `rightFileStart?: CommentPosition` and `leftFileStart?: CommentPosition`
+   (also `rightFileEnd` and `leftFileEnd` for completeness, though unused).
+3. Add `line: number | null` to `ActiveCommentThread` after `threadContext`.
+
+### Step 2 — `src/services/pr-client.ts`
+
+In both `mapThread` and `toActiveCommentThread`:
+
+```typescript
+const line =
+  thread.threadContext?.rightFileStart?.line ??
+  thread.threadContext?.leftFileStart?.line ??
+  null;
+```
+
+Add `line` to the returned object literal.
+
+### Step 3 — `src/commands/pr.ts`
+
+In `formatThreads`, replace the single-expression thread header with:
+
+```typescript
+const location = thread.threadContext
+  ? `${thread.threadContext}${thread.line !== null ? `:${thread.line}` : ''}`
+  : '(general)';
+lines.push('', `Thread #${thread.id} [${threadStatusLabel(thread.status)}] ${location}`);
+```
+
+### Step 4 — Tests
+
+**`pr-client.test.ts`** — add test cases for `mapThread`:
+- Input with `rightFileStart: { line: 42, offset: 1 }` → `line: 42`
+- Input with `rightFileStart` absent, `leftFileStart: { line: 7, offset: 3 }` → `line: 7`
+- Input with `threadContext` present but no position fields → `line: null`
+- Input with `threadContext` absent (general thread) → `line: null`
+
+Update all existing `ActiveCommentThread` fixtures to add `line: null`.
+
+**`pr-comments.test.ts`** — update fixtures; add assertions that the
+formatted output contains `:42` for threads with a known line.
+
+**`pr-comments-filters.test.ts`** — update fixtures to add `line: null`.
+
+## Verify
+
+```bash
+npm run lint
+npm test
+npm run build
+```
+
+All three must exit 0.

--- a/specs/028-pr-comment-line/research.md
+++ b/specs/028-pr-comment-line/research.md
@@ -1,0 +1,85 @@
+# Research: PR Comment Line Number Display
+
+**Branch**: `028-pr-comment-line` | **Date**: 2026-06-10
+
+## Decision 1 — Primary line-number source
+
+**Decision**: Use `threadContext.rightFileStart.line` as the primary value;
+fall back to `threadContext.leftFileStart.line` if absent.
+
+**Rationale**: The "right file" is the new (post-change) version, which is
+what reviewers see in the PR diff. `rightFileStart` is the position where the
+comment thread begins in that view. `leftFileStart` represents the same
+position in the old (base) version — available for threads anchored to deleted
+lines. Using right-first, left-fallback ensures the displayed line is as
+close as possible to the reviewer's current view.
+
+**Alternatives considered**:
+- Left-file only: would show stale lines for comments on new code.
+- Always right, no fallback: would show no line for threads on deleted lines.
+- Show both (e.g. `file.ts:L42 → R45`): too verbose; not requested by the issue.
+
+**Source**: Confirmed via Microsoft Learn
+([`CommentThreadContext`](https://learn.microsoft.com/javascript/api/azure-devops-extension-api/commentthreadcontext))
+and Context7 ADO REST API reference (PR threads GET response example).
+
+---
+
+## Decision 2 — `CommentPosition` field name
+
+**Decision**: The field is named `line` (integer, 1-based) as returned by the
+ADO REST API. The companion `offset` field (column) is intentionally out of
+scope.
+
+**Rationale**: Official API JSON example:
+```json
+"rightFileStart": { "line": 5, "offset": 1 }
+```
+Field name `line` is stable across API versions 5.x–7.1.
+
+**Source**: Context7 ADO REST API reference (PR threads GET response example,
+`api-version=7.1`).
+
+---
+
+## Decision 3 — No new API call needed
+
+**Decision**: The existing `GET .../pullRequests/{prId}/threads` response
+already includes `threadContext.rightFileStart` / `leftFileStart`. The CLI's
+`AzdoThread` type simply did not model these sub-fields; they were silently
+discarded by the JSON deserializer.
+
+**Rationale**: The ADO response object is parsed by native `fetch` → `response.json()`
+with no schema validation. Any field present in the JSON is available as long
+as the TypeScript interface declares it. Expanding `AzdoThread.threadContext`
+to include the position sub-objects is sufficient.
+
+**Alternatives considered**:
+- A separate `GET .../threads/{threadId}` per thread: unnecessary overhead,
+  same data already in the list response.
+
+---
+
+## Decision 4 — JSON output shape
+
+**Decision**: Add `line: number | null` as a top-level field on each thread
+object in the `--json` output. Do NOT change `threadContext` from `string`
+to an object.
+
+**Rationale**: Changing `threadContext` from a string to an object would be a
+breaking change for existing `--json` consumers. Adding a new sibling field
+is additive and backward-compatible, consistent with how `codeCommentCounts`
+was added in feature `023-pr-comments-status`.
+
+---
+
+## Decision 5 — Test fixture strategy
+
+**Decision**: Update all existing `ActiveCommentThread` fixtures to include
+`line: null`. Add new test cases in `pr-client.test.ts` for the four
+line-extraction scenarios.
+
+**Rationale**: TypeScript strict mode will require `line` on every
+`ActiveCommentThread` literal once the interface gains the field. Updating
+fixtures is mandatory. New test cases verify the mapping logic directly
+without needing end-to-end tests.

--- a/specs/028-pr-comment-line/spec.md
+++ b/specs/028-pr-comment-line/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: PR Comment Line Number Display
+
+**Feature Branch**: `028-pr-comment-line`
+**Created**: 2026-06-10
+**Status**: Draft
+**Issue**: #61
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View line numbers in human-readable output (Priority: P1)
+
+A developer runs `azdo pr comments` (with or without filters) and wants to
+know not only which file a code comment is anchored to, but exactly which line
+— so they can jump straight to that location in their editor without guessing.
+
+**Why this priority**: The primary ask in the issue. Without the line number
+the filename alone forces manual searching; this is the single change that
+delivers most of the value.
+
+**Independent Test**: Run `azdo pr comments` against a PR that has at least
+one code-anchored thread. The header line for each code-anchored thread must
+display `path/to/file.ext:42` (colon-line-number suffix). Threads with no
+file anchor are unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR with a code-anchored thread on line 42 of `foo.ts`,
+   **When** the user runs `azdo pr comments`,
+   **Then** the output includes a line like
+   `Thread #69293 [active] foo.ts:42` (line number appended after a colon).
+
+2. **Given** a PR with a general (non-file-anchored) thread,
+   **When** the user runs `azdo pr comments`,
+   **Then** the thread header displays the same format as today (no colon suffix).
+
+3. **Given** a code-anchored thread where the API returns only a left-side
+   (old-file) line position and no right-side position,
+   **When** the user runs `azdo pr comments`,
+   **Then** the left-side line number is used as the fallback.
+
+4. **Given** a code-anchored thread where the API returns a file path but no
+   line position at all,
+   **When** the user runs `azdo pr comments`,
+   **Then** just the file path is shown (no colon suffix), matching the
+   existing behaviour — the display degrades gracefully.
+
+---
+
+### User Story 2 - Access line numbers through JSON output (Priority: P2)
+
+A script or tool consuming `azdo pr comments --json` needs the line number for
+each thread so it can correlate comments with source lines without
+re-implementing ADO API parsing.
+
+**Why this priority**: Required parity: the issue explicitly asks for line
+numbers "also on JSON". Enables downstream automation.
+
+**Independent Test**: Run `azdo pr comments --json`. For a code-anchored
+thread with a known line number, the thread object in the JSON output must
+contain a numeric `line` field with the correct value. For a general thread
+the field must be absent or `null`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a code-anchored thread on line 42,
+   **When** the user runs `azdo pr comments --json`,
+   **Then** the thread object contains `"line": 42`.
+
+2. **Given** a general thread (no file anchor),
+   **When** the user runs `azdo pr comments --json`,
+   **Then** the thread object contains `"line": null` (field present,
+   value null — keeping a stable JSON shape).
+
+---
+
+### Edge Cases
+
+- Thread with `rightFileStart.line` present → use that value.
+- Thread with `rightFileStart` absent but `leftFileStart.line` present → use
+  `leftFileStart.line` as the fallback.
+- Thread with `threadContext` present (file path known) but no line position
+  in either side → `line` is `null`; human output shows only the file path.
+- Thread with `threadContext === null` (general thread) → `line` is `null`;
+  human output unchanged.
+- `--code-related-only` and `--hide-resolved` filters: line numbers appear on
+  all threads that pass the filter, regardless of which filters are active.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When displaying a code-anchored thread in human-readable output,
+  the system MUST append `:N` (colon + integer) after the file path, where `N`
+  is the line number, when a line position is available.
+- **FR-002**: The system MUST use `rightFileStart.line` as the primary source
+  of the line number; if absent, fall back to `leftFileStart.line`.
+- **FR-003**: When no line position is available for a code-anchored thread,
+  the system MUST show only the file path (no colon suffix), preserving the
+  current behaviour.
+- **FR-004**: When outputting JSON, each thread object MUST include a `line`
+  field: a positive integer when a line number is known, or `null` otherwise.
+- **FR-005**: General threads (no file anchor) MUST be unaffected in both
+  human and JSON output, except that JSON gains `"line": null` for shape
+  consistency.
+- **FR-006**: All existing flags (`--hide-resolved`, `--exclude-resolved`,
+  `--code-related-only`, `--json`, `--pr-number`) MUST continue to function
+  identically.
+- **FR-007**: The default output (no flags) MUST remain byte-for-byte
+  compatible with the prior release except for the addition of `:N` on
+  code-anchored thread headers where line data is now available.
+
+### Key Entities
+
+- **ThreadContext**: The per-thread file/position anchor returned by the ADO
+  API. Carries `filePath`, `rightFileStart { line, offset }`,
+  `rightFileEnd`, `leftFileStart { line, offset }`, `leftFileEnd`.
+- **ActiveCommentThread** (internal): The mapped thread shape used throughout
+  the CLI. Gains a `line: number | null` field alongside the existing
+  `threadContext: string | null` (file path).
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For every code-anchored comment thread whose ADO API response
+  includes a line position, the human-readable output displays `:N` after the
+  file path. Zero regressions on threads that lack a line position.
+- **SC-002**: `azdo pr comments --json` output for any thread includes a
+  `line` field. All existing JSON fields are preserved.
+- **SC-003**: Existing unit tests pass without modification. New unit tests
+  cover: (a) right-side line present, (b) right-side absent / left-side
+  present, (c) no line position, (d) general thread.
+- **SC-004**: `npm run lint && npm test && npm run build` exits 0 on the
+  feature branch.
+- **SC-005**: No change to the output of any command other than
+  `azdo pr comments` (and its JSON variant).
+
+---
+
+## Assumptions
+
+- The ADO `threads` REST endpoint already returns `threadContext.rightFileStart`
+  and `threadContext.leftFileStart`; the CLI is simply discarding them during
+  mapping. No new API call is required.
+- Line numbers are 1-based integers as supplied by the ADO API.
+- The `offset` (column) field is intentionally out of scope; only `line` is
+  displayed.

--- a/specs/028-pr-comment-line/spec.md
+++ b/specs/028-pr-comment-line/spec.md
@@ -58,7 +58,7 @@ numbers "also on JSON". Enables downstream automation.
 **Independent Test**: Run `azdo pr comments --json`. For a code-anchored
 thread with a known line number, the thread object in the JSON output must
 contain a numeric `line` field with the correct value. For a general thread
-the field must be absent or `null`.
+the field must be `null` (field is always present for a stable JSON shape).
 
 **Acceptance Scenarios**:
 
@@ -138,6 +138,14 @@ the field must be absent or `null`.
   feature branch.
 - **SC-005**: No change to the output of any command other than
   `azdo pr comments` (and its JSON variant).
+
+---
+
+## Clarifications
+
+### Session 2026-06-10
+
+- Q: US2 Independent Test stated "absent or null" for the `line` field on general threads — should it always be present as `null`? → A: Always present as `null` (consistent with FR-004, FR-005, and acceptance scenario 2 — stable JSON shape).
 
 ---
 

--- a/specs/028-pr-comment-line/tasks.md
+++ b/specs/028-pr-comment-line/tasks.md
@@ -19,7 +19,7 @@ Phase 4 verifies JSON output (US2 — implementation is automatic once foundatio
 **Purpose**: No new project infrastructure is needed — all files already exist. This phase
 confirms the starting state.
 
-- [ ] T001 Verify starting state: run `npm run lint && npm test && npm run build` from repo root and confirm all pass before any changes
+- [x] T001 Verify starting state: run `npm run lint && npm test && npm run build` from repo root and confirm all pass before any changes
 
 ---
 
@@ -30,16 +30,16 @@ both user stories.
 
 **⚠️ CRITICAL**: US1 and US2 implementation cannot begin until this phase is complete.
 
-- [ ] T002 Add `CommentPosition` interface (`{ line: number; offset: number }`) in `src/types/pull-request.ts` just before `AzdoThread`; do NOT export it (internal ADO detail)
-- [ ] T003 Expand `AzdoThread.threadContext` in `src/types/pull-request.ts` to include `rightFileStart?: CommentPosition`, `rightFileEnd?: CommentPosition`, `leftFileStart?: CommentPosition`, `leftFileEnd?: CommentPosition` alongside the existing `filePath?: string`
-- [ ] T004 Add `line: number | null` field to `ActiveCommentThread` in `src/types/pull-request.ts` after the `threadContext` field
-- [ ] T005 Update `mapThread()` in `src/services/pr-client.ts`: extract `line = thread.threadContext?.rightFileStart?.line ?? thread.threadContext?.leftFileStart?.line ?? null` and include it in the returned object
-- [ ] T006 Update `toActiveCommentThread()` in `src/services/pr-client.ts` with the same `line` extraction (mirrors T005)
-- [ ] T007 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-client.test.ts` to add `line: null` (TypeScript strict mode will require it)
-- [ ] T008 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comments.test.ts` to add `line: null`
-- [ ] T009 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comments-filters.test.ts` to add `line: null`
-- [ ] T010 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comment-state.test.ts` to add `line: null`
-- [ ] T011 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-status.test.ts` to add `line: null`
+- [x] T002 Add `CommentPosition` interface (`{ line: number; offset: number }`) in `src/types/pull-request.ts` just before `AzdoThread`; do NOT export it (internal ADO detail)
+- [x] T003 Expand `AzdoThread.threadContext` in `src/types/pull-request.ts` to include `rightFileStart?: CommentPosition`, `rightFileEnd?: CommentPosition`, `leftFileStart?: CommentPosition`, `leftFileEnd?: CommentPosition` alongside the existing `filePath?: string`
+- [x] T004 Add `line: number | null` field to `ActiveCommentThread` in `src/types/pull-request.ts` after the `threadContext` field
+- [x] T005 Update `mapThread()` in `src/services/pr-client.ts`: extract `line = thread.threadContext?.rightFileStart?.line ?? thread.threadContext?.leftFileStart?.line ?? null` and include it in the returned object
+- [x] T006 Update `toActiveCommentThread()` in `src/services/pr-client.ts` with the same `line` extraction (mirrors T005)
+- [x] T007 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-client.test.ts` to add `line: null` (TypeScript strict mode will require it)
+- [x] T008 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comments.test.ts` to add `line: null`
+- [x] T009 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comments-filters.test.ts` to add `line: null`
+- [x] T010 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comment-state.test.ts` to add `line: null`
+- [x] T011 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-status.test.ts` to add `line: null`
 
 **Checkpoint**: `npm run lint && npm test && npm run build` must pass after T011 before proceeding.
 
@@ -54,18 +54,18 @@ code-anchored threads. Each such thread's header must include `:<line>` suffix.
 
 ### Tests for User Story 1
 
-- [ ] T012 [US1] Add 4 new test cases to `tests/unit/pr-client.test.ts` for `mapThread()` line extraction:
+- [x] T012 [US1] Add 4 new test cases to `tests/unit/pr-client.test.ts` for `mapThread()` line extraction:
   - Case A: `rightFileStart: { line: 42, offset: 1 }` → `line: 42`
   - Case B: `rightFileStart` absent, `leftFileStart: { line: 7, offset: 3 }` → `line: 7`
   - Case C: `threadContext` present (filePath only), no position fields → `line: null`
   - Case D: `threadContext` absent (general thread) → `line: null`
-- [ ] T013 [US1] Add assertions to `tests/unit/pr-comments.test.ts` that the formatted output for a code-anchored thread with `line: 42` contains the string `:42`
-- [ ] T014 [US1] Add assertion to `tests/unit/pr-comments.test.ts` that a code-anchored thread with `line: null` shows only the file path (no colon suffix)
-- [ ] T015 [US1] Add assertion to `tests/unit/pr-comments.test.ts` that a general thread (`threadContext: null`, `line: null`) shows `(general)` (unchanged)
+- [x] T013 [US1] Add assertions to `tests/unit/pr-comments.test.ts` that the formatted output for a code-anchored thread with `line: 42` contains the string `:42`
+- [x] T014 [US1] Add assertion to `tests/unit/pr-comments.test.ts` that a code-anchored thread with `line: null` shows only the file path (no colon suffix)
+- [x] T015 [US1] Add assertion to `tests/unit/pr-comments.test.ts` that a general thread (`threadContext: null`, `line: null`) shows `(general)` (unchanged)
 
 ### Implementation for User Story 1
 
-- [ ] T016 [US1] Update `formatThreads()` in `src/commands/pr.ts` (line ~274): replace the thread header expression with a `location` variable that appends `:<line>` when `thread.line !== null`, falls back to just `thread.threadContext` when line is null, and uses `(general)` when `threadContext` is null
+- [x] T016 [US1] Update `formatThreads()` in `src/commands/pr.ts` (line ~274): replace the thread header expression with a `location` variable that appends `:<line>` when `thread.line !== null`, falls back to just `thread.threadContext` when line is null, and uses `(general)` when `threadContext` is null
 
 **Checkpoint**: US1 complete — `npm test` passes and human-readable output includes `:N` on code-anchored threads.
 
@@ -80,11 +80,11 @@ a `line` field: integer for code-anchored threads with known position, `null` ot
 
 ### Tests for User Story 2
 
-- [ ] T017 [US2] Add a `--json` output test to `tests/unit/pr-comments.test.ts`: verify that the serialised JSON for a thread with `line: 42` contains `"line":42` and for a general thread contains `"line":null`
+- [x] T017 [US2] Add a `--json` output test to `tests/unit/pr-comments.test.ts`: verify that the serialised JSON for a thread with `line: 42` contains `"line":42` and for a general thread contains `"line":null`
 
 ### Implementation for User Story 2
 
-- [ ] T018 [US2] Confirm no formatter change is needed for JSON output — `line` is automatically included because `ActiveCommentThread` now carries it and the JSON serialiser outputs all fields; add a code comment in `src/commands/pr.ts` near the JSON output path noting that `line` is structural (from T004)
+- [x] T018 [US2] Confirm no formatter change is needed for JSON output — `line` is automatically included because `ActiveCommentThread` now carries it and the JSON serialiser outputs all fields; add a code comment in `src/commands/pr.ts` near the JSON output path noting that `line` is structural (from T004)
 
 **Checkpoint**: US2 complete — JSON output verified in tests.
 
@@ -94,8 +94,8 @@ a `line` field: integer for code-anchored threads with known position, `null` ot
 
 **Purpose**: Finalise non-functional requirements before PR.
 
-- [ ] T019 Review `README.md` and update `azdo pr comments` command documentation to note that thread headers now show the line number (constitution requires README review before merge)
-- [ ] T020 Run full verification: `npm run lint && npm test && npm run build` and confirm all pass with zero errors
+- [x] T019 Review `README.md` and update `azdo pr comments` command documentation to note that thread headers now show the line number (constitution requires README review before merge)
+- [x] T020 Run full verification: `npm run lint && npm test && npm run build` and confirm all pass with zero errors
 
 ---
 

--- a/specs/028-pr-comment-line/tasks.md
+++ b/specs/028-pr-comment-line/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: PR Comment Line Number Display
+
+**Input**: Design documents from `specs/028-pr-comment-line/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/cli-commands.md ✅, quickstart.md ✅
+
+**Organization**: Tasks are grouped by phase. Phase 2 (Foundational) delivers the type and mapper
+changes that both user stories depend on. Phase 3 adds the human-readable formatter change (US1).
+Phase 4 verifies JSON output (US2 — implementation is automatic once foundational changes land).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project infrastructure is needed — all files already exist. This phase
+confirms the starting state.
+
+- [ ] T001 Verify starting state: run `npm run lint && npm test && npm run build` from repo root and confirm all pass before any changes
+
+---
+
+## Phase 2: Foundational — Type Layer and Mapper
+
+**Purpose**: Expand the ADO type and internal model to carry the line number. These changes block
+both user stories.
+
+**⚠️ CRITICAL**: US1 and US2 implementation cannot begin until this phase is complete.
+
+- [ ] T002 Add `CommentPosition` interface (`{ line: number; offset: number }`) in `src/types/pull-request.ts` just before `AzdoThread`; do NOT export it (internal ADO detail)
+- [ ] T003 Expand `AzdoThread.threadContext` in `src/types/pull-request.ts` to include `rightFileStart?: CommentPosition`, `rightFileEnd?: CommentPosition`, `leftFileStart?: CommentPosition`, `leftFileEnd?: CommentPosition` alongside the existing `filePath?: string`
+- [ ] T004 Add `line: number | null` field to `ActiveCommentThread` in `src/types/pull-request.ts` after the `threadContext` field
+- [ ] T005 Update `mapThread()` in `src/services/pr-client.ts`: extract `line = thread.threadContext?.rightFileStart?.line ?? thread.threadContext?.leftFileStart?.line ?? null` and include it in the returned object
+- [ ] T006 Update `toActiveCommentThread()` in `src/services/pr-client.ts` with the same `line` extraction (mirrors T005)
+- [ ] T007 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-client.test.ts` to add `line: null` (TypeScript strict mode will require it)
+- [ ] T008 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comments.test.ts` to add `line: null`
+- [ ] T009 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comments-filters.test.ts` to add `line: null`
+- [ ] T010 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-comment-state.test.ts` to add `line: null`
+- [ ] T011 [P] Update all `ActiveCommentThread` fixtures in `tests/unit/pr-status.test.ts` to add `line: null`
+
+**Checkpoint**: `npm run lint && npm test && npm run build` must pass after T011 before proceeding.
+
+---
+
+## Phase 3: User Story 1 — Line Numbers in Human-Readable Output (Priority: P1) 🎯 MVP
+
+**Goal**: `azdo pr comments` thread headers display `:N` after the file path for code-anchored threads.
+
+**Independent Test**: Run `azdo pr comments` (or use the unit tests) against a PR that has
+code-anchored threads. Each such thread's header must include `:<line>` suffix.
+
+### Tests for User Story 1
+
+- [ ] T012 [US1] Add 4 new test cases to `tests/unit/pr-client.test.ts` for `mapThread()` line extraction:
+  - Case A: `rightFileStart: { line: 42, offset: 1 }` → `line: 42`
+  - Case B: `rightFileStart` absent, `leftFileStart: { line: 7, offset: 3 }` → `line: 7`
+  - Case C: `threadContext` present (filePath only), no position fields → `line: null`
+  - Case D: `threadContext` absent (general thread) → `line: null`
+- [ ] T013 [US1] Add assertions to `tests/unit/pr-comments.test.ts` that the formatted output for a code-anchored thread with `line: 42` contains the string `:42`
+- [ ] T014 [US1] Add assertion to `tests/unit/pr-comments.test.ts` that a code-anchored thread with `line: null` shows only the file path (no colon suffix)
+- [ ] T015 [US1] Add assertion to `tests/unit/pr-comments.test.ts` that a general thread (`threadContext: null`, `line: null`) shows `(general)` (unchanged)
+
+### Implementation for User Story 1
+
+- [ ] T016 [US1] Update `formatThreads()` in `src/commands/pr.ts` (line ~274): replace the thread header expression with a `location` variable that appends `:<line>` when `thread.line !== null`, falls back to just `thread.threadContext` when line is null, and uses `(general)` when `threadContext` is null
+
+**Checkpoint**: US1 complete — `npm test` passes and human-readable output includes `:N` on code-anchored threads.
+
+---
+
+## Phase 4: User Story 2 — Line Numbers in JSON Output (Priority: P2)
+
+**Goal**: `azdo pr comments --json` thread objects include `"line": <number|null>`.
+
+**Independent Test**: Run `azdo pr comments --json` and inspect thread objects. Each must have
+a `line` field: integer for code-anchored threads with known position, `null` otherwise.
+
+### Tests for User Story 2
+
+- [ ] T017 [US2] Add a `--json` output test to `tests/unit/pr-comments.test.ts`: verify that the serialised JSON for a thread with `line: 42` contains `"line":42` and for a general thread contains `"line":null`
+
+### Implementation for User Story 2
+
+- [ ] T018 [US2] Confirm no formatter change is needed for JSON output — `line` is automatically included because `ActiveCommentThread` now carries it and the JSON serialiser outputs all fields; add a code comment in `src/commands/pr.ts` near the JSON output path noting that `line` is structural (from T004)
+
+**Checkpoint**: US2 complete — JSON output verified in tests.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalise non-functional requirements before PR.
+
+- [ ] T019 Review `README.md` and update `azdo pr comments` command documentation to note that thread headers now show the line number (constitution requires README review before merge)
+- [ ] T020 Run full verification: `npm run lint && npm test && npm run build` and confirm all pass with zero errors
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — run immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS both user stories
+- **US1 (Phase 3)**: Depends on Phase 2 completion
+- **US2 (Phase 4)**: Depends on Phase 2 completion; can run in parallel with Phase 3
+- **Polish (Phase 5)**: Depends on Phases 3 and 4
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational type changes (T002–T006); fixture updates (T007–T011)
+- **US2 (P2)**: Depends on Foundational type changes (T002–T006); fixture updates (T007–T011). Implementation is automatic; only test verification needed.
+- US1 and US2 can proceed in parallel after Phase 2.
+
+### Within Phases
+
+- T002 → T003 → T004 (sequential — build up the type incrementally)
+- T004 → T005, T006 (T005 and T006 can be parallel — different functions, same file)
+- T007–T011 can all run in parallel (different test files)
+- T012–T015 can run in parallel (all test additions, no inter-dependency)
+- T016 depends on T012–T015 (implement after test cases are written)
+
+---
+
+## Parallel Example: Phase 2 Fixture Updates
+
+```
+# After T004 (ActiveCommentThread gains line field):
+T007: update pr-client.test.ts fixtures
+T008: update pr-comments.test.ts fixtures
+T009: update pr-comments-filters.test.ts fixtures
+T010: update pr-comment-state.test.ts fixtures
+T011: update pr-status.test.ts fixtures
+# All five can run in parallel — different files
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (T001)
+2. Complete Phase 2 (T002–T011)
+3. Complete Phase 3 tests (T012–T015) — ensure they fail first
+4. Complete Phase 3 implementation (T016)
+5. **STOP and VALIDATE**: `npm test` passes, human output shows `:N`
+6. Optionally skip Phase 4 for a first increment
+
+### Full Delivery (Both Stories)
+
+1. Phases 1 → 2 → 3 and 4 (3 and 4 in parallel) → 5
+
+---
+
+## Notes
+
+- [P] tasks = different files, no shared state, safe to parallelise
+- T007–T011 (fixture updates) are mechanical: add `line: null` to every `ActiveCommentThread` object literal
+- T016 is the only source-code change outside types/services — one function, ~3 lines
+- SC-003 requires tests covering all four mapping cases (T012) and all output variants (T013–T015)
+- SC-004 (`npm run lint && npm test && npm run build`) is the gate before marking the PR ready

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -271,9 +271,8 @@ function formatThreads(prId: number, title: string, threads: ActiveCommentThread
   const lines = [`Comment threads for pull request #${prId}: ${title}`];
 
   for (const thread of threads) {
-    const location = thread.threadContext
-      ? `${thread.threadContext}${thread.line !== null ? `:${thread.line}` : ''}`
-      : '(general)';
+    const lineSuffix = thread.line === null ? '' : `:${thread.line}`;
+    const location = thread.threadContext ? `${thread.threadContext}${lineSuffix}` : '(general)';
     lines.push('', `Thread #${thread.id} [${threadStatusLabel(thread.status)}] ${location}`);
     for (const comment of thread.comments) {
       lines.push(`  ${comment.author ?? 'Unknown'}: ${comment.content}`);

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -271,7 +271,10 @@ function formatThreads(prId: number, title: string, threads: ActiveCommentThread
   const lines = [`Comment threads for pull request #${prId}: ${title}`];
 
   for (const thread of threads) {
-    lines.push('', `Thread #${thread.id} [${threadStatusLabel(thread.status)}] ${thread.threadContext ?? '(general)'}`);
+    const location = thread.threadContext
+      ? `${thread.threadContext}${thread.line !== null ? `:${thread.line}` : ''}`
+      : '(general)';
+    lines.push('', `Thread #${thread.id} [${threadStatusLabel(thread.status)}] ${location}`);
     for (const comment of thread.comments) {
       lines.push(`  ${comment.author ?? 'Unknown'}: ${comment.content}`);
     }

--- a/src/services/pr-client.ts
+++ b/src/services/pr-client.ts
@@ -226,10 +226,16 @@ function mapThread(thread: AzdoThread): ActiveCommentThread | null {
     return null;
   }
 
+  const line =
+    thread.threadContext?.rightFileStart?.line ??
+    thread.threadContext?.leftFileStart?.line ??
+    null;
+
   return {
     id: thread.id,
     status: thread.status ?? 'unknown',
     threadContext: thread.threadContext?.filePath ?? null,
+    line,
     comments,
   };
 }
@@ -238,10 +244,16 @@ function toActiveCommentThread(thread: AzdoThread): ActiveCommentThread {
   // Unlike mapThread() this does not drop threads whose visible comments
   // list is empty; the state-change path needs to round-trip any thread
   // the PATCH call returns so callers can confirm the new status.
+  const line =
+    thread.threadContext?.rightFileStart?.line ??
+    thread.threadContext?.leftFileStart?.line ??
+    null;
+
   return {
     id: thread.id,
     status: thread.status ?? 'unknown',
     threadContext: thread.threadContext?.filePath ?? null,
+    line,
     comments: thread.comments
       .map(mapComment)
       .filter((comment): comment is ActivePullRequestComment => comment !== null),

--- a/src/types/pull-request.ts
+++ b/src/types/pull-request.ts
@@ -87,6 +87,7 @@ export interface ActiveCommentThread {
   id: number;
   status: string;
   threadContext: string | null;
+  line: number | null;
   comments: ActivePullRequestComment[];
 }
 
@@ -121,11 +122,20 @@ export interface AzdoThreadListResponse {
   value: AzdoThread[];
 }
 
+interface CommentPosition {
+  line: number;
+  offset: number;
+}
+
 export interface AzdoThread {
   id: number;
   status?: string;
   threadContext?: {
     filePath?: string;
+    rightFileStart?: CommentPosition;
+    rightFileEnd?: CommentPosition;
+    leftFileStart?: CommentPosition;
+    leftFileEnd?: CommentPosition;
   };
   comments: AzdoComment[];
 }

--- a/tests/unit/pr-client.test.ts
+++ b/tests/unit/pr-client.test.ts
@@ -594,6 +594,7 @@ describe('pr-client', () => {
           id: 1,
           status: 'active',
           threadContext: '/src/file.ts',
+          line: null,
           comments: [
             {
               id: 10,
@@ -607,6 +608,7 @@ describe('pr-client', () => {
           id: 2,
           status: 'closed',
           threadContext: null,
+          line: null,
           comments: [
             {
               id: 12,
@@ -620,6 +622,7 @@ describe('pr-client', () => {
           id: 3,
           status: 'pending',
           threadContext: null,
+          line: null,
           comments: [
             {
               id: 13,
@@ -630,6 +633,94 @@ describe('pr-client', () => {
           ],
         },
       ]);
+    });
+
+    it('extracts line from rightFileStart when present', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          value: [
+            {
+              id: 10,
+              status: 'active',
+              threadContext: {
+                filePath: '/src/foo.ts',
+                rightFileStart: { line: 42, offset: 1 },
+                rightFileEnd: { line: 42, offset: 13 },
+              },
+              comments: [{ id: 1, author: { displayName: 'Alice' }, content: 'fix this', publishedDate: null }],
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
+      expect(result[0].line).toBe(42);
+    });
+
+    it('falls back to leftFileStart when rightFileStart is absent', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          value: [
+            {
+              id: 11,
+              status: 'active',
+              threadContext: {
+                filePath: '/src/foo.ts',
+                leftFileStart: { line: 7, offset: 3 },
+              },
+              comments: [{ id: 1, author: { displayName: 'Alice' }, content: 'old line', publishedDate: null }],
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
+      expect(result[0].line).toBe(7);
+    });
+
+    it('returns null line when threadContext has filePath but no position fields', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          value: [
+            {
+              id: 12,
+              status: 'active',
+              threadContext: { filePath: '/src/foo.ts' },
+              comments: [{ id: 1, author: { displayName: 'Alice' }, content: 'no pos', publishedDate: null }],
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
+      expect(result[0].threadContext).toBe('/src/foo.ts');
+      expect(result[0].line).toBeNull();
+    });
+
+    it('returns null line for general threads (no threadContext)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          value: [
+            {
+              id: 13,
+              status: 'active',
+              comments: [{ id: 1, author: { displayName: 'Bob' }, content: 'general', publishedDate: null }],
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
+      expect(result[0].threadContext).toBeNull();
+      expect(result[0].line).toBeNull();
     });
   });
 });

--- a/tests/unit/pr-client.test.ts
+++ b/tests/unit/pr-client.test.ts
@@ -38,7 +38,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await listPullRequests(context, 'repo-name', 'pat', 'feature/test');
 
@@ -65,7 +65,7 @@ describe('pr-client', () => {
         ok: true,
         status: 200,
         json: async () => ({ count: 0, value: [] }),
-      } as Response);
+      });
 
       await expect(listPullRequests(context, 'repo-name', 'pat', 'feature/test')).resolves.toEqual([]);
     });
@@ -74,7 +74,7 @@ describe('pr-client', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: false,
         status: 401,
-      } as Response);
+      });
 
       await expect(listPullRequests(context, 'repo-name', 'pat', 'feature/test')).rejects.toThrow('AUTH_FAILED');
     });
@@ -97,7 +97,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await listPullRequests(context, 'repo-name', 'pat', 'feature/x');
       expect(result).toEqual([
@@ -127,7 +127,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await listPullRequests(context, 'repo-name', 'pat', 'feature/y');
       expect(result[0].url).toBeNull();
@@ -148,7 +148,7 @@ describe('pr-client', () => {
           createdBy: { displayName: 'Alice' },
           _links: { web: { href: 'https://example.test/pr/64' } },
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestById(context, 'repo-name', 'pat', 64);
       expect(result).toEqual({
@@ -171,7 +171,7 @@ describe('pr-client', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: false,
         status: 404,
-      } as Response);
+      });
 
       await expect(getPullRequestById(context, 'repo-name', 'pat', 999999)).rejects.toThrow(/NOT_FOUND/);
     });
@@ -180,7 +180,7 @@ describe('pr-client', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: false,
         status: 401,
-      } as Response);
+      });
 
       await expect(getPullRequestById(context, 'repo-name', 'pat', 64)).rejects.toThrow('AUTH_FAILED');
     });
@@ -196,7 +196,7 @@ describe('pr-client', () => {
           sourceRefName: 'refs/heads/feature/y',
           targetRefName: 'refs/heads/develop',
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestById(context, 'repo-name', 'pat', 77);
       expect(result.url).toBeNull();
@@ -215,7 +215,7 @@ describe('pr-client', () => {
             { id: 1, author: { displayName: 'Alice' }, content: 'done', publishedDate: null },
           ],
         }),
-      } as Response);
+      });
 
       const result = await patchThreadStatus(context, 'repo-name', 'pat', 64, 17, 'fixed');
 
@@ -242,7 +242,7 @@ describe('pr-client', () => {
             { id: 1, author: { displayName: 'Alice' }, content: 'back open', publishedDate: null },
           ],
         }),
-      } as Response);
+      });
 
       const result = await patchThreadStatus(context, 'repo-name', 'pat', 64, 17, 'active');
 
@@ -257,7 +257,7 @@ describe('pr-client', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: false,
         status: 404,
-      } as Response);
+      });
 
       await expect(patchThreadStatus(context, 'repo-name', 'pat', 64, 9999, 'fixed')).rejects.toThrow(/NOT_FOUND/);
     });
@@ -266,7 +266,7 @@ describe('pr-client', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: false,
         status: 401,
-      } as Response);
+      });
 
       await expect(patchThreadStatus(context, 'repo-name', 'pat', 64, 17, 'fixed')).rejects.toThrow('AUTH_FAILED');
     });
@@ -306,7 +306,7 @@ describe('pr-client', () => {
             createdBy: { displayName: 'Alice' },
             _links: { web: { href: 'https://example.test/pr/34' } },
           }),
-        } as Response);
+        });
 
       const result = await openPullRequest(context, 'repo-name', 'pat', 'feature/test', 'New PR', 'Description');
 
@@ -344,7 +344,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await openPullRequest(context, 'repo-name', 'pat', 'feature/test', 'Ignored', 'Ignored');
 
@@ -390,7 +390,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       await expect(openPullRequest(context, 'repo-name', 'pat', 'feature/test', 'Title', 'Description'))
         .rejects.toThrow('AMBIGUOUS_PRS:22,23');
@@ -443,7 +443,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestChecks(context, 'repo-name', 'pat', 12);
 
@@ -488,7 +488,7 @@ describe('pr-client', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: false,
         status: 401,
-      } as Response);
+      });
 
       await expect(getPullRequestChecks(context, 'repo-name', 'pat', 12)).rejects.toThrow('AUTH_FAILED');
     });
@@ -500,7 +500,7 @@ describe('pr-client', () => {
         ok: true,
         status: 200,
         json: async () => ({ id: 'abc-123-guid', name: 'test-project' }),
-      } as Response);
+      });
 
       const id = await resolveProjectId(context, 'pat');
       expect(id).toBe('abc-123-guid');
@@ -528,7 +528,7 @@ describe('pr-client', () => {
             { evaluationId: 'e6', status: 'notSet', configuration: { id: 15, type: { displayName: 'Not set' } } },
           ],
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestPolicyEvaluations(context, 'pat', 'proj-guid', 12);
 
@@ -585,7 +585,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
 
@@ -653,7 +653,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
       expect(result[0].line).toBe(42);
@@ -676,7 +676,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
       expect(result[0].line).toBe(7);
@@ -696,7 +696,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
       expect(result[0].threadContext).toBe('/src/foo.ts');
@@ -716,7 +716,7 @@ describe('pr-client', () => {
             },
           ],
         }),
-      } as Response);
+      });
 
       const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
       expect(result[0].threadContext).toBeNull();

--- a/tests/unit/pr-comment-state.test.ts
+++ b/tests/unit/pr-comment-state.test.ts
@@ -64,6 +64,7 @@ function thread(id: number, status: string) {
     id,
     status,
     threadContext: null,
+    line: null,
     comments: [{ id: id * 10, author: 'Alice', content: 'note', publishedAt: null }],
   };
 }

--- a/tests/unit/pr-comments-filters.test.ts
+++ b/tests/unit/pr-comments-filters.test.ts
@@ -52,24 +52,28 @@ const codeActive = {
   id: 1,
   status: 'active',
   threadContext: 'src/app.ts',
+  line: null,
   comments: [comment('please rename this')],
 };
 const codeResolved = {
   id: 2,
   status: 'fixed',
   threadContext: 'src/util.ts',
+  line: null,
   comments: [comment('fixed already')],
 };
 const generalActive = {
   id: 3,
   status: 'active',
   threadContext: null,
+  line: null,
   comments: [comment('overall LGTM discussion')],
 };
 const generalResolved = {
   id: 4,
   status: 'closed',
   threadContext: null,
+  line: null,
   comments: [comment('closed discussion')],
 };
 

--- a/tests/unit/pr-comments.test.ts
+++ b/tests/unit/pr-comments.test.ts
@@ -93,7 +93,7 @@ describe('pr comments command --pr-number', () => {
       url: 'https://example.test/pr/64',
     });
     vi.mocked(getPullRequestThreads).mockResolvedValue([
-      { id: 500, status: 'active', threadContext: null, comments: [{ id: 1, author: 'A', content: 'hi', publishedAt: null }] },
+      { id: 500, status: 'active', threadContext: null, line: null, comments: [{ id: 1, author: 'A', content: 'hi', publishedAt: null }] },
     ]);
 
     await run(['--pr-number', '64']);
@@ -157,6 +157,7 @@ describe('pr comments command', () => {
         id: 100,
         status: 'active',
         threadContext: '/src/file.ts',
+        line: null,
         comments: [
           { id: 1, author: 'Alice', content: 'Please fix this', publishedAt: '2026-03-27T00:00:00Z' },
         ],
@@ -165,6 +166,7 @@ describe('pr comments command', () => {
         id: 101,
         status: 'pending',
         threadContext: null,
+        line: null,
         comments: [
           { id: 2, author: 'Bob', content: 'Still waiting', publishedAt: '2026-03-27T00:00:00Z' },
         ],
@@ -176,6 +178,7 @@ describe('pr comments command', () => {
     const output = getStdout();
     expect(output).toContain('Comment threads for pull request #12: Test PR');
     expect(output).toContain('Thread #100 [active] /src/file.ts');
+    expect(output).not.toContain('/src/file.ts:');
     expect(output).toContain('  Alice: Please fix this');
     expect(output).toContain('Thread #101 [pending] (general)');
     expect(output).toContain('  Bob: Still waiting');
@@ -183,12 +186,12 @@ describe('pr comments command', () => {
 
   it('renders a [resolved] indicator for every settled thread status (FR-003)', async () => {
     vi.mocked(getPullRequestThreads).mockResolvedValue([
-      { id: 200, status: 'active', threadContext: null, comments: [{ id: 1, author: 'A', content: 'open', publishedAt: null }] },
-      { id: 201, status: 'fixed', threadContext: null, comments: [{ id: 2, author: 'A', content: 'done', publishedAt: null }] },
-      { id: 202, status: 'wontFix', threadContext: null, comments: [{ id: 3, author: 'A', content: 'no thanks', publishedAt: null }] },
-      { id: 203, status: 'closed', threadContext: null, comments: [{ id: 4, author: 'A', content: 'closed', publishedAt: null }] },
-      { id: 204, status: 'byDesign', threadContext: null, comments: [{ id: 5, author: 'A', content: 'intentional', publishedAt: null }] },
-      { id: 205, status: 'pending', threadContext: null, comments: [{ id: 6, author: 'A', content: 'waiting', publishedAt: null }] },
+      { id: 200, status: 'active', threadContext: null, line: null, comments: [{ id: 1, author: 'A', content: 'open', publishedAt: null }] },
+      { id: 201, status: 'fixed', threadContext: null, line: null, comments: [{ id: 2, author: 'A', content: 'done', publishedAt: null }] },
+      { id: 202, status: 'wontFix', threadContext: null, line: null, comments: [{ id: 3, author: 'A', content: 'no thanks', publishedAt: null }] },
+      { id: 203, status: 'closed', threadContext: null, line: null, comments: [{ id: 4, author: 'A', content: 'closed', publishedAt: null }] },
+      { id: 204, status: 'byDesign', threadContext: null, line: null, comments: [{ id: 5, author: 'A', content: 'intentional', publishedAt: null }] },
+      { id: 205, status: 'pending', threadContext: null, line: null, comments: [{ id: 6, author: 'A', content: 'waiting', publishedAt: null }] },
     ]);
 
     await run([]);
@@ -204,10 +207,10 @@ describe('pr comments command', () => {
 
   it('hides settled threads when --hide-resolved is set (FR-004a)', async () => {
     vi.mocked(getPullRequestThreads).mockResolvedValue([
-      { id: 300, status: 'active', threadContext: null, comments: [{ id: 1, author: 'A', content: 'open', publishedAt: null }] },
-      { id: 301, status: 'fixed', threadContext: null, comments: [{ id: 2, author: 'A', content: 'done', publishedAt: null }] },
-      { id: 302, status: 'pending', threadContext: null, comments: [{ id: 3, author: 'A', content: 'waiting', publishedAt: null }] },
-      { id: 303, status: 'closed', threadContext: null, comments: [{ id: 4, author: 'A', content: 'shut', publishedAt: null }] },
+      { id: 300, status: 'active', threadContext: null, line: null, comments: [{ id: 1, author: 'A', content: 'open', publishedAt: null }] },
+      { id: 301, status: 'fixed', threadContext: null, line: null, comments: [{ id: 2, author: 'A', content: 'done', publishedAt: null }] },
+      { id: 302, status: 'pending', threadContext: null, line: null, comments: [{ id: 3, author: 'A', content: 'waiting', publishedAt: null }] },
+      { id: 303, status: 'closed', threadContext: null, line: null, comments: [{ id: 4, author: 'A', content: 'shut', publishedAt: null }] },
     ]);
 
     await run(['--hide-resolved']);
@@ -221,7 +224,7 @@ describe('pr comments command', () => {
 
   it('still shows settled threads when --hide-resolved is absent', async () => {
     vi.mocked(getPullRequestThreads).mockResolvedValue([
-      { id: 400, status: 'fixed', threadContext: null, comments: [{ id: 1, author: 'A', content: 'done', publishedAt: null }] },
+      { id: 400, status: 'fixed', threadContext: null, line: null, comments: [{ id: 1, author: 'A', content: 'done', publishedAt: null }] },
     ]);
 
     await run([]);
@@ -236,6 +239,7 @@ describe('pr comments command', () => {
         id: 100,
         status: 'active',
         threadContext: '/src/file.ts',
+        line: null,
         comments: [
           { id: 1, author: 'Alice', content: 'Please fix this', publishedAt: '2026-03-27T00:00:00Z' },
         ],
@@ -252,6 +256,7 @@ describe('pr comments command', () => {
           id: 100,
           status: 'active',
           threadContext: '/src/file.ts',
+          line: null,
           comments: [
             {
               id: 1,
@@ -263,5 +268,80 @@ describe('pr comments command', () => {
         },
       ],
     });
+  });
+
+  it('appends :N to thread header when line is known (US1)', async () => {
+    vi.mocked(getPullRequestThreads).mockResolvedValue([
+      {
+        id: 100,
+        status: 'active',
+        threadContext: '/src/foo.ts',
+        line: 42,
+        comments: [{ id: 1, author: 'Alice', content: 'fix this', publishedAt: null }],
+      },
+    ]);
+
+    await run([]);
+
+    expect(getStdout()).toContain('Thread #100 [active] /src/foo.ts:42');
+  });
+
+  it('shows only file path when line is null for code-anchored thread (US1)', async () => {
+    vi.mocked(getPullRequestThreads).mockResolvedValue([
+      {
+        id: 101,
+        status: 'active',
+        threadContext: '/src/bar.ts',
+        line: null,
+        comments: [{ id: 1, author: 'Alice', content: 'note', publishedAt: null }],
+      },
+    ]);
+
+    await run([]);
+
+    const output = getStdout();
+    expect(output).toContain('Thread #101 [active] /src/bar.ts');
+    expect(output).not.toContain('/src/bar.ts:');
+  });
+
+  it('shows (general) for threads with no file anchor (US1)', async () => {
+    vi.mocked(getPullRequestThreads).mockResolvedValue([
+      {
+        id: 102,
+        status: 'active',
+        threadContext: null,
+        line: null,
+        comments: [{ id: 1, author: 'Bob', content: 'general comment', publishedAt: null }],
+      },
+    ]);
+
+    await run([]);
+
+    expect(getStdout()).toContain('Thread #102 [active] (general)');
+  });
+
+  it('includes line number in JSON output when known (US2)', async () => {
+    vi.mocked(getPullRequestThreads).mockResolvedValue([
+      {
+        id: 100,
+        status: 'active',
+        threadContext: '/src/file.ts',
+        line: 42,
+        comments: [{ id: 1, author: 'Alice', content: 'fix this', publishedAt: null }],
+      },
+      {
+        id: 101,
+        status: 'active',
+        threadContext: null,
+        line: null,
+        comments: [{ id: 2, author: 'Bob', content: 'general note', publishedAt: null }],
+      },
+    ]);
+
+    await run(['--json']);
+
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.threads[0].line).toBe(42);
+    expect(parsed.threads[1].line).toBeNull();
   });
 });

--- a/tests/unit/pr-status.test.ts
+++ b/tests/unit/pr-status.test.ts
@@ -237,10 +237,10 @@ describe('pr status command', () => {
   it('prints open/closed counts of code-anchored comments, excluding general threads', async () => {
     vi.mocked(listPullRequests).mockResolvedValue([makePullRequest({ title: 'Test PR', status: 'active' })]);
     vi.mocked(getPullRequestThreads).mockResolvedValue([
-      { id: 1, status: 'active', threadContext: 'src/a.ts', comments: [] },
-      { id: 2, status: 'active', threadContext: 'src/b.ts', comments: [] },
-      { id: 3, status: 'fixed', threadContext: 'src/c.ts', comments: [] },
-      { id: 4, status: 'active', threadContext: null, comments: [] }, // general — excluded
+      { id: 1, status: 'active', threadContext: 'src/a.ts', line: null, comments: [] },
+      { id: 2, status: 'active', threadContext: 'src/b.ts', line: null, comments: [] },
+      { id: 3, status: 'fixed', threadContext: 'src/c.ts', line: null, comments: [] },
+      { id: 4, status: 'active', threadContext: null, line: null, comments: [] }, // general — excluded
     ]);
 
     await run([]);
@@ -251,7 +251,7 @@ describe('pr status command', () => {
   it('reports zero code-comment counts when there are no code-anchored threads', async () => {
     vi.mocked(listPullRequests).mockResolvedValue([makePullRequest({ title: 'Test PR', status: 'active' })]);
     vi.mocked(getPullRequestThreads).mockResolvedValue([
-      { id: 4, status: 'active', threadContext: null, comments: [] },
+      { id: 4, status: 'active', threadContext: null, line: null, comments: [] },
     ]);
 
     await run([]);


### PR DESCRIPTION
# PR Report: PR Comment Line Number Display

**Branch**: `028-pr-comment-line`
**Date**: 2026-06-10
**Spec**: [specs/028-pr-comment-line/spec.md](specs/028-pr-comment-line/spec.md)

## Summary

`azdo pr comments` now displays the line number alongside the file path for each code-anchored comment thread (e.g. `/src/foo.ts:42`). The Azure DevOps threads endpoint has always returned `rightFileStart`/`leftFileStart` position data inside `threadContext`; the CLI was discarding it. This PR expands the type layer to capture those fields, extracts the line number during mapping, and surfaces it in both human-readable and `--json` output.

## What's New

- **`src/types/pull-request.ts` — ADO type expansion**: Added `CommentPosition` interface; expanded `AzdoThread.threadContext` to include `rightFileStart`, `rightFileEnd`, `leftFileStart`, `leftFileEnd` position fields that the API already returns.
- **`src/types/pull-request.ts` — internal model**: `ActiveCommentThread` gains `line: number | null` — positive integer when a line position is known, `null` for general threads or when the API provides no position.
- **`src/services/pr-client.ts` — mapper**: `mapThread()` and `toActiveCommentThread()` now extract `line` from `rightFileStart.line` (primary) with `leftFileStart.line` as fallback.
- **`src/commands/pr.ts` — formatter**: `formatThreads()` appends `:<line>` after the file path when `line` is non-null. General threads and threads without position data are unchanged.
- **`--json` output**: `line` field added to each thread object automatically; `threadContext` remains a `string | null` for backward compatibility.

## Testing

- **Unit — mapper**: 4 new test cases in `tests/unit/pr-client.test.ts` covering right-side line, left-side fallback, file-only (no position), and general thread.
- **Unit — formatter**: assertions in `tests/unit/pr-comments.test.ts` verify `:N` suffix present when `line` is known, absent when null, and `(general)` unchanged.
- **Unit — JSON**: assertion verifies `line` field present in serialised output for both code-anchored and general threads.
- **Regression**: existing fixtures in `pr-comments-filters.test.ts`, `pr-comment-state.test.ts`, `pr-status.test.ts` updated with `line: null` — all existing behaviour preserved.

## Notes

- `offset` (column) is intentionally not exposed; only `line` is shown.
- No new runtime dependencies added.

Closes #61
