### PR TITLE
fix(sonarcloud): resolve all MAJOR-severity code smells

### DIFF
--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -58,14 +58,14 @@ sudo apt-get install -y gnome-keyring libsecret-tools xvfb xdotool python3-dbus 
 
 # Initialise the GNOME Keyring default collection so credential-store
 # integration tests can run without a real desktop session (skipped if absent).
-[ -f scripts/setup-keyring.sh ] && bash scripts/setup-keyring.sh || true
+[[ -f scripts/setup-keyring.sh ]] && bash scripts/setup-keyring.sh || true
 
 # tokensave: semantic code intelligence for Claude Code and Codex CLI.
 echo "Installing tokensave..."
 TOKENSAVE_TAG=$(curl -sI https://github.com/aovestdipaperino/tokensave/releases/latest | grep -i '^location:' | sed 's|.*/tag/||;s/\r//')
 TOKENSAVE_VERSION="${TOKENSAVE_TAG#v}"
 ARCH=$(uname -m)
-if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+if [[ "$ARCH" = "aarch64" ]] || [[ "$ARCH" = "arm64" ]]; then
     TOKENSAVE_ARCH="aarch64-linux"
 else
     TOKENSAVE_ARCH="x86_64-linux"
@@ -106,15 +106,15 @@ else
     echo "Homebrew already installed, skipping."
 fi
 
-if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+if [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
     BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
-elif [ -x /opt/homebrew/bin/brew ]; then
+elif [[ -x /opt/homebrew/bin/brew ]]; then
     BREW_BIN="/opt/homebrew/bin/brew"
 else
     BREW_BIN=""
 fi
 
-if [ -n "$BREW_BIN" ]; then
+if [[ -n "$BREW_BIN" ]]; then
     BREW_SHELLENV_LINE="eval \"\$($BREW_BIN shellenv)\""
     append_if_missing "$BREW_SHELLENV_LINE" "$HOME/.zprofile"
     append_if_missing "$BREW_SHELLENV_LINE" "$HOME/.zshrc"

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -101,19 +101,23 @@ NEW_PROJECT_TYPE=""
 #==============================================================================
 
 log_info() {
-    echo "INFO: $1"
+    local message="$1"
+    echo "INFO: $message"
 }
 
 log_success() {
-    echo "✓ $1"
+    local message="$1"
+    echo "✓ $message"
 }
 
 log_error() {
-    echo "ERROR: $1" >&2
+    local message="$1"
+    echo "ERROR: $message" >&2
 }
 
 log_warning() {
-    echo "WARNING: $1" >&2
+    local message="$1"
+    echo "WARNING: $message" >&2
 }
 
 # Cleanup function for temporary files
@@ -514,14 +518,12 @@ update_existing_agent_file() {
     fi
     
     # Ensure Cursor .mdc files have YAML frontmatter for auto-inclusion
-    if [[ "$target_file" == *.mdc ]]; then
-        if ! head -1 "$temp_file" | grep -q '^---'; then
-            local frontmatter_file
-            frontmatter_file=$(mktemp) || { rm -f "$temp_file"; return 1; }
-            printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" > "$frontmatter_file"
-            cat "$temp_file" >> "$frontmatter_file"
-            mv "$frontmatter_file" "$temp_file"
-        fi
+    if [[ "$target_file" == *.mdc ]] && ! head -1 "$temp_file" | grep -q '^---'; then
+        local frontmatter_file
+        frontmatter_file=$(mktemp) || { rm -f "$temp_file"; return 1; }
+        printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" > "$frontmatter_file"
+        cat "$temp_file" >> "$frontmatter_file"
+        mv "$frontmatter_file" "$temp_file"
     fi
 
     # Move temp file to target atomically
@@ -556,11 +558,9 @@ update_agent_file() {
     # Create directory if it doesn't exist
     local target_dir
     target_dir=$(dirname "$target_file")
-    if [[ ! -d "$target_dir" ]]; then
-        if ! mkdir -p "$target_dir"; then
-            log_error "Failed to create directory: $target_dir"
-            return 1
-        fi
+    if [[ ! -d "$target_dir" ]] && ! mkdir -p "$target_dir"; then
+        log_error "Failed to create directory: $target_dir"
+        return 1
     fi
     
     if [[ ! -f "$target_file" ]]; then

--- a/scripts/link-skills.sh
+++ b/scripts/link-skills.sh
@@ -13,7 +13,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SRC_DIR="$REPO_ROOT/.agents/skills"
 DEST_DIR="$REPO_ROOT/.claude/skills"
 
-if [ ! -d "$SRC_DIR" ]; then
+if [[ ! -d "$SRC_DIR" ]]; then
     echo "link-skills: $SRC_DIR does not exist; nothing to link."
     exit 0
 fi
@@ -27,7 +27,7 @@ for skill_path in "$SRC_DIR"/*/; do
     dest="$DEST_DIR/$skill_name"
     rel_target="../../.agents/skills/$skill_name"
 
-    if [ -e "$dest" ] && [ ! -L "$dest" ]; then
+    if [[ -e "$dest" ]] && [[ ! -L "$dest" ]]; then
         echo "link-skills: $dest exists and is not a symlink; leaving it alone."
         skipped=$((skipped + 1))
         continue
@@ -39,8 +39,8 @@ done
 
 pruned=0
 for link in "$DEST_DIR"/*; do
-    [ -L "$link" ] || continue
-    if [ ! -e "$link" ]; then
+    [[ -L "$link" ]] || continue
+    if [[ ! -e "$link" ]]; then
         rm "$link"
         pruned=$((pruned + 1))
     fi

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -75,7 +75,8 @@ function autoDetectZeroMatch(branch: string): string {
 // listed in the order Azure DevOps returned them (no re-sort), each `#`-prefixed
 // and `, `-joined. Never prompts, even under a TTY.
 function autoDetectMultiMatch(branch: string, ids: number[]): string {
-  return `Multiple open pull requests match branch ${branch}: ${ids.map((id) => `#${id}`).join(', ')}. Re-run with --pr-number to choose.`;
+  const idList = ids.map((id) => `#${id}`).join(', ');
+  return `Multiple open pull requests match branch ${branch}: ${idList}. Re-run with --pr-number to choose.`;
 }
 
 // Writes a contract error line verbatim to stderr (no "Error: " prefix, unlike

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,12 +65,8 @@ program.hook("postAction", async () => {
   }
 });
 
-async function main(): Promise<void> {
-  await program.parseAsync();
+await program.parseAsync();
 
-  if (process.argv.length <= 2) {
-    program.help();
-  }
+if (process.argv.length <= 2) {
+  program.help();
 }
-
-void main();


### PR DESCRIPTION
## Summary

Fixes all 13 MAJOR-severity SonarCloud issues on `develop`:

| Rule | File(s) | Fix |
|------|---------|-----|
| `shelldre:S7688` (6×) | `.devcontainer/postcreate.sh`, `scripts/link-skills.sh` | Replace `[ ]` with `[[ ]]` for all conditionals |
| `shelldre:S7679` (4×) | `.specify/scripts/bash/update-agent-context.sh` | Assign positional params to named locals in log helpers |
| `shelldre:S1066` (2×) | `.specify/scripts/bash/update-agent-context.sh` | Merge nested `if` into enclosing one |
| `typescript:S4624` (1×) | `src/commands/pr.ts` | Extract inner template literal to a variable |
| `typescript:S7785` (1×) | `src/index.ts` | Replace `void main()` wrapper with top-level `await` |

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npm test` — 909 tests passed, 0 failures
- [ ] SonarCloud re-analysis clears the 13 MAJOR issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)