### PR TITLE
feat(#65): add azdo pr comments reply command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ bd close <id>         # Complete work
 - JSON file at `~/.azdo/config.json` (existing; extended with an `organizations` map) (025-multi-org-support)
 - TypeScript 5.x (strict mode), Node.js LTS + commander.js (CLI), native `fetch` (HTTP) — no new deps (027-work-item-relations)
 - TypeScript 5.x (strict: true) + commander.js (CLI framework), native `fetch` (HTTP), vitest (tests) (028-pr-comment-line)
+- TypeScript 5.x (strict mode) + commander.js (CLI), native `fetch` (HTTP) (029-pr-comment-reply)
 
 ## Recent Changes
 - 019-fix-pr-command: `azdo pr` now recognises HTTPS remotes with a `<user>[:<token>]@` userinfo prefix and an optional `.git` suffix (one-time, sanitised stderr credential warning; host allow-list unchanged). The single-PR commands (`pr comments` / `comment-resolve` / `comment-reopen`) document the branch→PR auto-detection rule in `--help` and fail cleanly on zero/multi-match; `pr status` stays a multi-PR list (decision A). No new runtime deps.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ azdo pr status                          # PR checks (status + branch policies + 
 azdo pr comment-resolve 17 --pr-number 64   # idempotent: exit 0 even when already resolved
 azdo pr comment-reopen 17  --pr-number 64
 
+# Reply to a PR comment thread
+azdo pr comments reply 148 "Great suggestion, I'll address it."          # human-readable output
+azdo pr comments reply 148 "Done." --pr-number 64 --json                 # JSON: { pullRequestId, threadId, commentId, content }
+azdo pr comment-reply 148 "Done."  --pr-number 64                        # flat alias, identical behaviour
+
 # Pipelines — list, inspect runs, wait (exit code = result), start
 azdo pipeline list --filter ci
 azdo pipeline get-runs 12 --branch develop --limit 1

--- a/specs/029-pr-comment-reply/checklists/requirements.md
+++ b/specs/029-pr-comment-reply/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: PR Comment Reply
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/029-pr-comment-reply/contracts/api-calls.md
+++ b/specs/029-pr-comment-reply/contracts/api-calls.md
@@ -1,0 +1,91 @@
+# Azure DevOps API contracts — 029-pr-comment-reply
+
+All calls authenticated with the existing `authHeaders(cred)` Basic-auth helper in `src/services/azdo-client.ts`. All calls go through `fetchWithErrors` so auth/permission/network errors map to the repo's standard `AzdoError` codes.
+
+Base URL: `https://dev.azure.com/{org}/{project}/_apis/git/repositories/{repo}/`  
+API version param: `api-version=7.1`.
+
+---
+
+## `POST /pullRequests/{prId}/threads/{threadId}/comments` — post comment (new)
+
+```
+POST /pullRequests/{prId}/threads/{threadId}/comments?api-version=7.1
+Content-Type: application/json
+Authorization: Basic <pat-b64>
+
+{
+  "content": "<reply text>",
+  "parentCommentId": 0,
+  "commentType": 1
+}
+```
+
+- `parentCommentId: 0` — new top-level comment in the thread (not nested)
+- `commentType: 1` — text comment (enum value for `"text"`)
+- `content` — the reply text verbatim; up to 150,000 characters (ADO limit)
+
+### Response (200)
+
+```json
+{
+  "id": 3,
+  "parentCommentId": 0,
+  "author": {
+    "displayName": "Gian Maria",
+    "id": "..."
+  },
+  "content": "Great suggestion!",
+  "publishedDate": "2026-06-15T13:00:00.000Z",
+  "lastUpdatedDate": "2026-06-15T13:00:00.000Z",
+  "commentType": "text"
+}
+```
+
+Only `id`, `author.displayName`, `content`, and `publishedDate` are read by the CLI. All other fields are ignored.
+
+### Error mapping
+
+| HTTP | AzdoError code | CLI stderr message |
+|------|----------------|--------------------|
+| 401 | `AUTH_FAILED` | "Authentication failed; run `azdo auth login`." |
+| 403 | `PERMISSION_DENIED` | "Permission denied posting to thread #\<id\>." |
+| 404 | `NOT_FOUND` | "Thread #\<id\> not found on pull request #\<pr\>." |
+| 5xx | `HTTP_<code>` | "Azure DevOps returned \<code\>; retry later." |
+| network | `NETWORK_ERROR` | "Network error contacting Azure DevOps." |
+
+### New service helper
+
+```typescript
+export async function postThreadComment(
+  context: AzdoContext,
+  repo: string,
+  cred: AuthCredential,
+  prId: number,
+  threadId: number,
+  content: string,
+): Promise<PostedPrComment>
+```
+
+Located in `src/services/pr-client.ts`. Constructs the URL, sends the POST, reads the 200 response body via `readJsonResponse<AzdoCreatedComment>`, and maps it to `PostedPrComment`.
+
+### URL construction
+
+```typescript
+function buildThreadCommentUrl(context: AzdoContext, repo: string, prId: number, threadId: number): URL {
+  return new URL(
+    `https://dev.azure.com/${encodeURIComponent(context.org)}/${encodeURIComponent(context.project)}` +
+    `/_apis/git/repositories/${encodeURIComponent(repo)}` +
+    `/pullRequests/${prId}/threads/${threadId}/comments?api-version=7.1`
+  );
+}
+```
+
+---
+
+## Existing API calls reused without modification
+
+| Endpoint | Used for |
+|----------|---------|
+| `GET /pullRequests?sourceRefName=...` | Branch-based PR lookup (via `listPullRequests`) |
+| `GET /pullRequests/{prId}` | Explicit `--pr-number` lookup (via `getPullRequestById`) |

--- a/specs/029-pr-comment-reply/contracts/cli-commands.md
+++ b/specs/029-pr-comment-reply/contracts/cli-commands.md
@@ -1,0 +1,85 @@
+# CLI command contracts — 029-pr-comment-reply
+
+Both commands share the same behaviour. Only the name/registration point differs.
+
+Exit-code convention: **0** on success, **non-zero** on any validation / not-found / auth / network error.
+
+---
+
+## `azdo pr comments reply <threadId> "<text>"` *(canonical)*
+
+Registered as a subcommand of `azdo pr comments`.
+
+### Positional arguments
+
+| Name | Type | Required | Behaviour |
+|------|------|----------|-----------|
+| `threadId` | integer | yes | Numeric ID of the target thread. Must be a positive integer. Validated before any network call. |
+| `text` | string | yes | The reply text to post. Must be non-empty after trimming. Validated before any network call. |
+
+### Options
+
+| Flag | Type | Required | Default | Behaviour |
+|------|------|----------|---------|-----------|
+| `--org <org>` | string | no | from `AzdoContext` | Azure DevOps organisation |
+| `--project <project>` | string | no | from `AzdoContext` | Azure DevOps project |
+| `--pr-number <N>` | integer | no | branch-based | Target PR directly, bypassing branch lookup |
+| `--json` | boolean | no | false | Emit result as JSON on stdout |
+
+### Exit codes
+
+| Code | When |
+|------|------|
+| 0 | Comment posted successfully |
+| 1 | Validation failure (non-integer or missing threadId, empty text, invalid --pr-number) |
+| 1 | PR not found (branch lookup or --pr-number) |
+| 1 | Thread not found on the PR |
+| 1 | Auth failure, permission denied, network error, or server error |
+
+### Output (stdout, success)
+
+**Human-readable** (default):
+```
+Reply posted to thread #<threadId> on pull request #<prId>.
+```
+
+**`--json`**:
+```json
+{
+  "pullRequestId": 22,
+  "threadId": 148,
+  "commentId": 3,
+  "content": "Great suggestion!"
+}
+```
+
+### Error messages (stderr)
+
+- `Invalid thread id "<raw>"; expected a positive integer.`
+- `Reply text must not be empty.`
+- `Invalid --pr-number "<raw>"; expected a positive integer.`
+- `No open pull request matches branch <branch>. Pass --pr-number to target a specific PR, or push the branch and open a pull request.`
+- `Multiple open pull requests match branch <branch>: #<id>, #<id>. Re-run with --pr-number to choose.`
+- `Pull request #<N> not found in <org>/<project>/<repo>.`
+- `Thread #<id> not found on pull request #<pr>.`
+- `Unable to post comment: <mapped-http-error>.`
+
+---
+
+## `azdo pr comment-reply <threadId> "<text>"` *(alias)*
+
+Registered as a top-level subcommand of `azdo pr` (alongside `comment-resolve` and `comment-reopen`).
+
+**Identical** in all respects to `azdo pr comments reply`: same positional arguments, same options, same output, same exit codes, same error messages.
+
+The `--help` description reads:
+```
+Post a reply to a pull request comment thread (alias of "azdo pr comments reply")
+```
+
+---
+
+## Backwards compatibility
+
+- `azdo pr comments` with no subcommand: unaffected — `reply` is an additional subcommand.
+- All existing `azdo pr` subcommands: unaffected — `comment-reply` is additive.

--- a/specs/029-pr-comment-reply/data-model.md
+++ b/specs/029-pr-comment-reply/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: PR Comment Reply
+
+**Date**: 2026-06-15
+
+## New types
+
+### `PostedPrComment` (new, `src/types/pull-request.ts`)
+
+Maps the ADO `POST /threads/{threadId}/comments` response to the CLI's type system.
+
+```typescript
+export interface PostedPrComment {
+  id: number;           // The new comment's ID within the thread
+  author: string | null; // displayName of the commenter (null if backend omits it)
+  content: string;       // The text that was posted
+  publishedAt: string | null; // ISO-8601 date from publishedDate, null if absent
+}
+```
+
+**Rationale**: Mirrors `ActivePullRequestComment` (same field names, same nullability rules) for consistency. `id` is load-bearing for the `--json` output `commentId` field.
+
+### `PrCommentReplyResult` (new, `src/commands/pr.ts` — local, not exported)
+
+The shape emitted on `--json`:
+
+```typescript
+interface PrCommentReplyResult {
+  pullRequestId: number;
+  threadId: number;
+  commentId: number;
+  content: string;
+}
+```
+
+**Rationale**: Flat shape consistent with `ThreadStateChangeResult`. Carries the contextual IDs (`pullRequestId`, `threadId`) that are not in the API response body.
+
+## Existing types reused without modification
+
+| Type | File | Used for |
+|------|------|---------|
+| `AzdoContext` | `src/types/work-item.ts` | org/project/repo context |
+| `AuthCredential` | `src/types/work-item.ts` | PAT / OAuth token |
+| `BranchPullRequestMatch` | `src/types/pull-request.ts` | resolved PR from branch/id lookup |
+| `ResolvedThreadTarget` | `src/commands/pr.ts` | reused resolver result |
+| `PrCommandOptions` | `src/commands/pr.ts` | `--org`, `--project`, `--pr-number`, `--json` |
+
+## New raw ADO response type
+
+### `AzdoCreatedComment` (new, `src/types/pull-request.ts`)
+
+Minimal shape for the `POST /comments` 200 response — only the fields the CLI reads:
+
+```typescript
+export interface AzdoCreatedComment {
+  id: number;
+  author?: { displayName?: string };
+  content?: string;
+  publishedDate?: string;
+}
+```
+
+**Rationale**: ADO returns many more fields; only these are needed to build `PostedPrComment`. Mirrors `AzdoComment` (the existing GET response type) to stay consistent.

--- a/specs/029-pr-comment-reply/plan.md
+++ b/specs/029-pr-comment-reply/plan.md
@@ -1,0 +1,63 @@
+# Implementation Plan: PR Comment Reply
+
+**Branch**: `029-pr-comment-reply` | **Date**: 2026-06-15 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/029-pr-comment-reply/spec.md`
+
+## Summary
+
+Add `azdo pr comments reply <threadId> "<text>"` (canonical) and `azdo pr comment-reply <threadId> "<text>"` (alias) commands to post a new comment to an existing Azure DevOps PR thread, using `POST /pullRequests/{prId}/threads/{threadId}/comments?api-version=7.1`. Follows the same structural pattern as `comment-resolve` / `comment-reopen`: a shared resolver (`resolveThreadTarget`) + a dedicated service function + two commander.js command factories.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode)  
+**Primary Dependencies**: commander.js (CLI), native `fetch` (HTTP)  
+**Storage**: N/A  
+**Testing**: vitest  
+**Target Platform**: Node.js LTS  
+**Project Type**: CLI  
+**Performance Goals**: Single API round-trip; same response-time envelope as other PR sub-commands  
+**Constraints**: No new runtime dependencies; strict TypeScript; must pass ESLint + tsup build  
+**Scale/Scope**: Single command, no state, no caching
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First | ✅ Pass | commander.js command; stdout success, stderr errors; `--json` flag; meaningful exit codes |
+| II. TypeScript Strict | ✅ Pass | New interfaces typed explicitly; no `any`; `unknown` + type guard on API response |
+| III. Single Responsibility | ✅ Pass | Command posts one comment to one thread; shared `resolveThreadTarget` handles PR resolution (reuse) |
+| IV. npm Distribution | ✅ Pass | No new deps; tsup build unaffected |
+| V. Simplicity | ✅ Pass | One new service function, two command factories (one shared body), one new type |
+| VI. ADO API Research | ✅ Pass | `POST /threads/{threadId}/comments` confirmed via Microsoft Learn MCP (api-version 7.1) |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-pr-comment-reply/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── contracts/           ← Phase 1 output
+│   ├── cli-commands.md
+│   └── api-calls.md
+└── tasks.md             ← Phase 2 output (speckit-tasks)
+```
+
+### Source Code (affected files only)
+
+```text
+src/
+├── types/
+│   └── pull-request.ts   ← add PostedPrComment interface
+├── services/
+│   └── pr-client.ts      ← add postThreadComment()
+└── commands/
+    └── pr.ts             ← add runCommentReply(), createPrCommentsReplyCommand(),
+                             createPrCommentReplyCommand(), register both in createPrCommand()
+
+tests/
+└── unit/
+    └── pr-client.test.ts  ← add postThreadComment() unit tests (mock fetch)
+```

--- a/specs/029-pr-comment-reply/pr-report.md
+++ b/specs/029-pr-comment-reply/pr-report.md
@@ -1,0 +1,30 @@
+# PR Report: PR Comment Reply
+
+**Branch**: `029-pr-comment-reply`
+**Date**: 2026-06-15
+**Spec**: [specs/029-pr-comment-reply/spec.md](../029-pr-comment-reply/spec.md)
+
+## Summary
+
+Adds `azdo pr comments reply <threadId> "<text>"` (and the flat alias `azdo pr comment-reply`) to post a new text comment into an existing pull request thread via the ADO REST API. Fills the read/write gap in the PR comments surface: the CLI could already list threads but had no way to respond to reviewer feedback programmatically.
+
+## What's New
+
+- **`src/types/pull-request.ts`**: Two new interfaces — `AzdoCreatedComment` (raw ADO POST /comments response shape) and `PostedPrComment` (mapped result exposed to command code).
+- **`src/services/pr-client.ts`**: New `postThreadComment()` service function — builds the URL, POSTs `{ content, parentCommentId: 0, commentType: 1 }`, maps the 200 response to `PostedPrComment`.
+- **`src/commands/pr.ts`**: `runCommentReply()` action (validates inputs, verifies thread exists, calls service, prints result); `createPrCommentsReplyCommand()` registered under `azdo pr comments reply`; `createPrCommentReplyCommand()` alias registered at `azdo pr comment-reply`.
+- **`tests/unit/pr-client.test.ts`**: Unit tests for `postThreadComment()` covering success, 401, 403, 404, and network-error paths.
+
+## Breaking Changes
+
+None — `comments reply` and `comment-reply` are purely additive subcommands.
+
+## Testing
+
+- **Unit**: `postThreadComment()` tested with mocked `fetch` across all error paths.
+- **Manual**: `azdo pr comments reply <threadId> "text"` and `--json` variant validated against a real ADO PR; `azdo pr comment-reply` alias produces identical output.
+
+## Notes
+
+- `parentCommentId: 0` adds a top-level comment to the thread (not nested); this matches "reply to thread" semantics per the ADO API contract.
+- PR state is not pre-validated client-side — the server decides (consistent with clarification Q2 default applied during spec phase).

--- a/specs/029-pr-comment-reply/pr-report.md
+++ b/specs/029-pr-comment-reply/pr-report.md
@@ -21,8 +21,9 @@ None — `comments reply` and `comment-reply` are purely additive subcommands.
 
 ## Testing
 
-- **Unit**: `postThreadComment()` tested with mocked `fetch` across all error paths.
-- **Manual**: `azdo pr comments reply <threadId> "text"` and `--json` variant validated against a real ADO PR; `azdo pr comment-reply` alias produces identical output.
+- **Unit**: 6 new tests for `postThreadComment()` covering success, null-author response, 401, 403, 404, and network error. All 915 tests pass (18 pre-existing skips, 0 failures).
+- **Build**: `npm run build` ✓ (0 TypeScript errors).
+- **Lint**: `npm run lint` ✓ (0 errors; 2 pre-existing warnings in `audit-log.test.ts` — unrelated to this feature).
 
 ## Notes
 

--- a/specs/029-pr-comment-reply/research.md
+++ b/specs/029-pr-comment-reply/research.md
@@ -1,0 +1,86 @@
+# Research: PR Comment Reply
+
+**Date**: 2026-06-15  
+**Source**: Microsoft Learn MCP server (api-version 7.1)
+
+## 1. ADO REST API — POST thread comment
+
+**Decision**: Use `POST /pullRequests/{prId}/threads/{threadId}/comments?api-version=7.1`
+
+**Endpoint**:
+```
+POST https://dev.azure.com/{org}/{project}/_apis/git/repositories/{repo}/pullRequests/{prId}/threads/{threadId}/comments?api-version=7.1
+Content-Type: application/json
+Authorization: Basic <pat-b64>
+
+{
+  "content": "<reply text>",
+  "parentCommentId": 0,
+  "commentType": 1
+}
+```
+
+- `parentCommentId: 0` — adds a new top-level comment to the thread (not nested under an existing comment). This matches the user's intent of "replying to a thread".
+- `commentType: 1` — `text` (regular user comment). Using `unknown` (0) would work but `text` is semantically correct.
+- `content` — up to 150,000 characters per ADO documentation.
+
+**Response (200)**:
+```json
+{
+  "id": 2,
+  "parentCommentId": 1,
+  "author": { "displayName": "...", "id": "..." },
+  "content": "Good idea",
+  "publishedDate": "2016-11-01T16:30:51.383Z",
+  "lastUpdatedDate": "2016-11-01T16:30:51.383Z",
+  "commentType": "text"
+}
+```
+
+**Rationale**: This is the only ADO REST endpoint for adding a comment to an existing thread. The distinction between "create thread" (`POST /threads`) and "add comment to thread" (`POST /threads/{id}/comments`) is important — the feature requests the latter.
+
+**Alternatives considered**: `POST /threads` would create a NEW top-level thread; this is explicitly out of scope.
+
+## 2. Command structure — canonical vs alias
+
+**Decision**: `azdo pr comments reply` is canonical; `azdo pr comment-reply` is an alias (commander.js `.alias()`).
+
+**Rationale**: Owner explicitly chose `comments reply` as primary (issue #65 clarification Q1-A). The alias `comment-reply` preserves consistency with existing `comment-resolve` / `comment-reopen` commands for users who prefer the flat pattern.
+
+**Implementation**: Two `Command` factory functions — `createPrCommentsReplyCommand()` returns the `reply` subcommand (registered under `comments`), and `createPrCommentReplyCommand()` returns the top-level `comment-reply` command. Both delegate to a shared `runCommentReply()` function.
+
+**Alternatives considered**: Single `Command` with `.alias()` at the `pr` level — rejected because commander.js command aliases work at the parent level, not across hierarchy levels. Separate factories sharing the same action body is the correct pattern.
+
+## 3. PR resolution — branch-based vs explicit
+
+**Decision**: Reuse existing `resolveThreadTarget()` from the `comment-resolve` / `comment-reopen` path.
+
+**Rationale**: The PR resolution logic (branch lookup vs `--pr-number`) is already well-tested and handles all edge cases. Extracting it once (already done) avoids duplication (Constitution III).
+
+**Note on PR state**: No pre-validation of PR state (per clarification Q2 default). The API call proceeds regardless; a server-side `403` or `404` surfaces as a clear error.
+
+## 4. Output shape — `PostedPrComment`
+
+**Decision**: New exported interface in `pull-request.ts` that maps from the ADO response.
+
+Fields kept:
+- `id` — the new comment's ID (used in `--json` output as `commentId`)
+- `author` — `string | null` (displayName), consistent with `ActivePullRequestComment`
+- `content` — the posted text (echoed back for confirmation)
+- `publishedAt` — ISO date string or null
+
+**Rationale**: Mirrors `ActivePullRequestComment` shape for consistency. The `--json` output uses a flat `PrCommentReplyResult` that also carries `pullRequestId` and `threadId` (from the call context, not the response body).
+
+## 5. Error mapping
+
+The existing `fetchWithErrors` + `handlePrCommandError` pattern covers:
+
+| HTTP | User message |
+|------|-------------|
+| 401 | AUTH_FAILED → "Authentication failed; run `azdo auth login`." |
+| 403 | PERMISSION_DENIED → "Permission denied posting to thread #\<id\>." |
+| 404 | NOT_FOUND → "Thread #\<id\> not found on pull request #\<pr\>." |
+| 5xx | HTTP_\<code\> → "Azure DevOps returned \<code\>; retry later." |
+| network | NETWORK_ERROR → "Network error contacting Azure DevOps." |
+
+No new error-handling infrastructure required.

--- a/specs/029-pr-comment-reply/spec.md
+++ b/specs/029-pr-comment-reply/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: PR Comment Reply
+
+**Feature Branch**: `029-pr-comment-reply`  
+**Created**: 2026-06-15  
+**Status**: Draft  
+**Input**: User description: "Add command to post replies to pull request comments in Azure DevOps CLI"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reply to a PR thread (Priority: P1)
+
+An automation script or developer needs to post a reply to a specific comment thread on an Azure DevOps pull request without leaving the terminal. They have already listed the comments (via `azdo pr comments`) and know the thread ID they want to respond to.
+
+**Why this priority**: This is the core MVP — the ability to write back to a PR thread. All other stories depend on this capability existing first.
+
+**Independent Test**: Can be fully tested by running `azdo pr comments reply <threadId> "some text"` on a PR with a known thread, then re-running `azdo pr comments` and confirming the reply appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated user with a PR open on the current branch, **When** the user runs `azdo pr comments reply <threadId> "reply text"`, **Then** the reply is posted to the specified thread and the CLI prints a confirmation including the PR number, thread ID, and comment ID.
+2. **Given** an authenticated user who specifies `--pr-number <N>`, **When** the user runs `azdo pr comments reply <threadId> "reply text" --pr-number <N>`, **Then** the reply is posted to the specified PR's thread regardless of the current git branch.
+3. **Given** the user provides an empty string as reply text, **When** the command runs, **Then** the CLI exits with a non-zero code and prints a clear error message before contacting the server.
+
+---
+
+### User Story 2 - JSON output for scripted use (Priority: P2)
+
+A script or automation tool needs structured confirmation after posting a reply, to record the new comment ID or verify the post succeeded.
+
+**Why this priority**: Consistent with the rest of the `azdo` CLI which supports `--json` on every command; important for programmatic use (the primary use case described in the issue).
+
+**Independent Test**: Can be fully tested by running `azdo pr comments reply <threadId> "text" --json` and parsing the JSON output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a successful reply post, **When** `--json` is supplied, **Then** the CLI emits a single JSON object containing at least `pullRequestId`, `threadId`, `commentId`, and `content`.
+2. **Given** a failed post (e.g. thread not found), **When** `--json` is supplied, **Then** the CLI still exits non-zero and the error goes to stderr; stdout is empty.
+
+---
+
+### User Story 3 - Clear error messages for invalid inputs (Priority: P3)
+
+A user accidentally supplies a non-existent thread ID or a thread ID belonging to a different PR. The CLI should tell them what went wrong without ambiguity.
+
+**Why this priority**: Reduces user frustration and support burden when the command is misused; lower priority because the happy path is more critical.
+
+**Independent Test**: Can be fully tested by invoking the command with a non-existent thread ID and verifying the error message and exit code.
+
+**Acceptance Scenarios**:
+
+1. **Given** a thread ID that does not exist on the target PR, **When** the user runs the reply command, **Then** the CLI exits non-zero and prints `Thread #<id> not found on pull request #<pr>.` to stderr.
+2. **Given** no active PR for the current branch and no `--pr-number` flag, **When** the user runs the reply command, **Then** the CLI exits non-zero and prints `No active pull request found for branch <branch>.` to stderr.
+3. **Given** a non-integer value as the thread ID, **When** the user runs the reply command, **Then** the CLI exits non-zero and prints a validation error before making any network call.
+
+---
+
+### Edge Cases
+
+- What happens when the reply text contains special characters (quotes, newlines, Unicode)?
+  - System must preserve the text exactly as supplied and post it to the thread without mangling.
+- What happens when the thread is already resolved/closed?
+  - System posts the reply and succeeds; the ADO API allows replies to resolved threads. If the server rejects it, the CLI surfaces the server error clearly.
+- What happens when the user is not authorised to post on the PR (e.g. read-only membership)?
+  - System exits non-zero with a permission-denied message without crashing.
+- What happens when the network is unavailable?
+  - System exits non-zero with a network error message.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Users MUST be able to post a text reply to an existing pull request comment thread by specifying the thread ID and reply text as command arguments.
+- **FR-002**: Users MUST be able to target a specific PR by number (`--pr-number`) instead of relying on branch-based resolution, consistent with the existing `azdo pr comments` behaviour.
+- **FR-003**: The command MUST accept a `--json` flag that causes it to emit the newly created comment's details (PR number, thread ID, comment ID, content) as a JSON object on stdout.
+- **FR-004**: The command MUST validate that the thread ID is a positive integer and the reply text is non-empty before making any network call, exiting non-zero with a clear message on failure.
+- **FR-005**: The command MUST return a non-zero exit code and a human-readable error on stderr for all failure conditions (auth failure, thread not found, PR not found, network error, permission denied).
+- **FR-006**: The command MUST print a human-readable success confirmation to stdout on a successful post (e.g. `Reply posted to thread #<id> on pull request #<pr>.`), unless `--json` is active.
+- **FR-007**: The command MUST honour the global `--org` and `--project` flags consistent with all other `azdo pr` sub-commands.
+
+### Key Entities
+
+- **Pull Request**: An open or draft code review request identified by a numeric ID within an organisation/project/repository.
+- **Comment Thread**: A conversation thread on a pull request, identified by a numeric thread ID. A thread may contain one or more comments and has a status (active, resolved, etc.).
+- **Comment**: An individual reply within a thread, created by posting text content to the thread.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can post a reply to a PR comment thread in a single command invocation, without copying thread IDs into a browser or separate API tool.
+- **SC-002**: The command completes and prints confirmation within the same response-time envelope as the existing read commands (no perceptible additional latency beyond the single write API call).
+- **SC-003**: All failure cases produce a non-zero exit code and a stderr message that identifies what failed — users can diagnose the problem without reading source code.
+- **SC-004**: The `--json` output is stable and parseable, enabling scripts to record the new comment ID without screen-scraping.
+
+## Assumptions
+
+- The feature targets replies to **existing threads** only; creating a new top-level thread (not attached to an existing comment) is out of scope for this iteration.
+- Multi-line reply text is supported via normal shell quoting (`$'line1\nline2'` or a here-string) — no special `--multi-line` flag is needed.
+- The command runs in the same authentication context as the other `azdo` commands (PAT-based or OAuth, whichever is configured).
+- Thread IDs shown by `azdo pr comments` are the same IDs accepted by this command — no translation layer is needed.

--- a/specs/029-pr-comment-reply/spec.md
+++ b/specs/029-pr-comment-reply/spec.md
@@ -59,7 +59,9 @@ A user accidentally supplies a non-existent thread ID or a thread ID belonging t
 - What happens when the reply text contains special characters (quotes, newlines, Unicode)?
   - System must preserve the text exactly as supplied and post it to the thread without mangling.
 - What happens when the thread is already resolved/closed?
-  - System posts the reply and succeeds; the ADO API allows replies to resolved threads. If the server rejects it, the CLI surfaces the server error clearly.
+  - System posts the reply regardless of thread status; the server decides whether to accept it. If the server rejects it, the CLI surfaces the error clearly.
+- What happens when the target PR is abandoned or completed?
+  - The command does not pre-validate PR state; the server's response determines the outcome. Any server-side rejection is surfaced as a clear error message.
 - What happens when the user is not authorised to post on the PR (e.g. read-only membership)?
   - System exits non-zero with a permission-denied message without crashing.
 - What happens when the network is unavailable?
@@ -69,7 +71,7 @@ A user accidentally supplies a non-existent thread ID or a thread ID belonging t
 
 ### Functional Requirements
 
-- **FR-001**: Users MUST be able to post a text reply to an existing pull request comment thread by specifying the thread ID and reply text as command arguments.
+- **FR-001**: Users MUST be able to post a text reply to an existing pull request comment thread using `azdo pr comments reply <threadId> "<text>"`. The command MUST also be accessible as `azdo pr comment-reply <threadId> "<text>"` (alias); both forms are equivalent.
 - **FR-002**: Users MUST be able to target a specific PR by number (`--pr-number`) instead of relying on branch-based resolution, consistent with the existing `azdo pr comments` behaviour.
 - **FR-003**: The command MUST accept a `--json` flag that causes it to emit the newly created comment's details (PR number, thread ID, comment ID, content) as a JSON object on stdout.
 - **FR-004**: The command MUST validate that the thread ID is a positive integer and the reply text is non-empty before making any network call, exiting non-zero with a clear message on failure.
@@ -98,3 +100,10 @@ A user accidentally supplies a non-existent thread ID or a thread ID belonging t
 - Multi-line reply text is supported via normal shell quoting (`$'line1\nline2'` or a here-string) — no special `--multi-line` flag is needed.
 - The command runs in the same authentication context as the other `azdo` commands (PAT-based or OAuth, whichever is configured).
 - Thread IDs shown by `azdo pr comments` are the same IDs accepted by this command — no translation layer is needed.
+
+## Clarifications
+
+### Session 2026-06-15
+
+- Q: Which command form should be canonical? → A: `azdo pr comments reply <threadId> "<text>"` is the primary (shown in `--help` and docs); `azdo pr comment-reply <threadId> "<text>"` is supported as an alias for consistency with `comment-resolve` / `comment-reopen`.
+- Q: Should the reply command restrict to open/active PRs only, or any PR state? → A: Any PR state — let the server decide; surface any server-side rejection as a clear error. *(default applied after 60-min timeout; owner may revise before planning)*

--- a/specs/029-pr-comment-reply/tasks.md
+++ b/specs/029-pr-comment-reply/tasks.md
@@ -16,7 +16,7 @@
 
 **Purpose**: No new project or dependency setup is needed (existing TypeScript/commander.js project, no new runtime deps). Single verification task.
 
-- [ ] T001 Confirm branch `029-pr-comment-reply` is checked out and up to date with `origin/029-pr-comment-reply`; run `npm install` to ensure lockfile is consistent
+- [x] T001 Confirm branch `029-pr-comment-reply` is checked out and up to date with `origin/029-pr-comment-reply`; run `npm install` to ensure lockfile is consistent
 
 ---
 
@@ -26,9 +26,9 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T002 Add `AzdoCreatedComment` and `PostedPrComment` interfaces to `src/types/pull-request.ts` (per `data-model.md` — shapes for the POST /comments API response and the CLI's mapped result type)
-- [ ] T003 [P] Add `buildThreadCommentUrl()` (internal) and `postThreadComment()` (exported) to `src/services/pr-client.ts` — POST to `/pullRequests/{prId}/threads/{threadId}/comments?api-version=7.1` with `{ content, parentCommentId: 0, commentType: 1 }`, map response to `PostedPrComment`
-- [ ] T004 [P] Add `postThreadComment()` unit tests in `tests/unit/pr-client.test.ts` — mock `fetch` to cover: success 200, auth failure 401, permission denied 403, thread not found 404, network error
+- [x] T002 Add `AzdoCreatedComment` and `PostedPrComment` interfaces to `src/types/pull-request.ts` (per `data-model.md` — shapes for the POST /comments API response and the CLI's mapped result type)
+- [x] T003 [P] Add `buildThreadCommentUrl()` (internal) and `postThreadComment()` (exported) to `src/services/pr-client.ts` — POST to `/pullRequests/{prId}/threads/{threadId}/comments?api-version=7.1` with `{ content, parentCommentId: 0, commentType: 1 }`, map response to `PostedPrComment`
+- [x] T004 [P] Add `postThreadComment()` unit tests in `tests/unit/pr-client.test.ts` — mock `fetch` to cover: success 200, auth failure 401, permission denied 403, thread not found 404, network error
 
 **Checkpoint**: `postThreadComment()` is tested and the types are in place — user story implementation can begin.
 
@@ -42,9 +42,9 @@
 
 ### Implementation for User Story 1
 
-- [ ] T005 [US1] Add `runCommentReply()` action function in `src/commands/pr.ts` — reuse `resolveThreadTarget()` for PR resolution; validate `threadIdRaw` as positive integer and `text` as non-empty (exit 1 with `Reply text must not be empty.` on failure); fetch threads with `getPullRequestThreads()` and find the target thread (exit 1 with `Thread #<id> not found on pull request #<pr>.` if missing); call `postThreadComment()`; print `Reply posted to thread #<threadId> on pull request #<prId>.\n` to stdout
-- [ ] T006 [US1] Add `createPrCommentsReplyCommand()` factory in `src/commands/pr.ts` — `new Command('reply')`, argument `<threadId>`, argument `<text>`, options `--org`, `--project`, `--pr-number` (reuse `PR_NUMBER_HELP`), action delegates to `runCommentReply()`
-- [ ] T007 [US1] Register the reply subcommand: inside `createPrCommentsCommand()` in `src/commands/pr.ts`, add `command.addCommand(createPrCommentsReplyCommand())` before `return command`
+- [x] T005 [US1] Add `runCommentReply()` action function in `src/commands/pr.ts` — reuse `resolveThreadTarget()` for PR resolution; validate `threadIdRaw` as positive integer and `text` as non-empty (exit 1 with `Reply text must not be empty.` on failure); fetch threads with `getPullRequestThreads()` and find the target thread (exit 1 with `Thread #<id> not found on pull request #<pr>.` if missing); call `postThreadComment()`; print `Reply posted to thread #<threadId> on pull request #<prId>.\n` to stdout
+- [x] T006 [US1] Add `createPrCommentsReplyCommand()` factory in `src/commands/pr.ts` — `new Command('reply')`, argument `<threadId>`, argument `<text>`, options `--org`, `--project`, `--pr-number` (reuse `PR_NUMBER_HELP`), action delegates to `runCommentReply()`
+- [x] T007 [US1] Register the reply subcommand: inside `createPrCommentsCommand()` in `src/commands/pr.ts`, add `command.addCommand(createPrCommentsReplyCommand())` before `return command`
 
 **Checkpoint**: `azdo pr comments reply <threadId> "<text>"` works end-to-end on a real PR. Human-readable output only at this point.
 
@@ -58,8 +58,8 @@
 
 ### Implementation for User Story 2
 
-- [ ] T008 [US2] Add `PrCommentReplyResult` local interface in `src/commands/pr.ts` — `{ pullRequestId: number; threadId: number; commentId: number; content: string }`
-- [ ] T009 [US2] Add `--json` option to `createPrCommentsReplyCommand()` in `src/commands/pr.ts`; extend `runCommentReply()` to accept `options.json` — when true, emit `JSON.stringify(result, null, 2)` to stdout instead of the human-readable line; on `--json` + error, errors still go to stderr and stdout stays empty
+- [x] T008 [US2] Add `PrCommentReplyResult` local interface in `src/commands/pr.ts` — `{ pullRequestId: number; threadId: number; commentId: number; content: string }`
+- [x] T009 [US2] Add `--json` option to `createPrCommentsReplyCommand()` in `src/commands/pr.ts`; extend `runCommentReply()` to accept `options.json` — when true, emit `JSON.stringify(result, null, 2)` to stdout instead of the human-readable line; on `--json` + error, errors still go to stderr and stdout stays empty
 
 **Checkpoint**: `azdo pr comments reply <threadId> "<text>" --json` emits the structured JSON object.
 
@@ -73,8 +73,8 @@
 
 ### Implementation for User Story 3
 
-- [ ] T010 [US3] Add `createPrCommentReplyCommand()` factory in `src/commands/pr.ts` — `new Command('comment-reply')`, identical arguments/options to `createPrCommentsReplyCommand()`, same `runCommentReply()` action, description: `'Post a reply to a pull request comment thread (alias of "azdo pr comments reply")'`
-- [ ] T011 [US3] Register alias: inside `createPrCommand()` in `src/commands/pr.ts`, add `command.addCommand(createPrCommentReplyCommand())` alongside the existing `comment-resolve` and `comment-reopen` registrations
+- [x] T010 [US3] Add `createPrCommentReplyCommand()` factory in `src/commands/pr.ts` — `new Command('comment-reply')`, identical arguments/options to `createPrCommentsReplyCommand()`, same `runCommentReply()` action, description: `'Post a reply to a pull request comment thread (alias of "azdo pr comments reply")'`
+- [x] T011 [US3] Register alias: inside `createPrCommand()` in `src/commands/pr.ts`, add `command.addCommand(createPrCommentReplyCommand())` alongside the existing `comment-resolve` and `comment-reopen` registrations
 
 **Checkpoint**: Both `azdo pr comments reply` and `azdo pr comment-reply` work end-to-end.
 
@@ -84,8 +84,8 @@
 
 **Purpose**: Documentation, final build verification, and README update (required by constitution before merge).
 
-- [ ] T012 [P] Update `README.md` — add `azdo pr comments reply` and `azdo pr comment-reply` to the PR commands section with usage examples matching the contract in `contracts/cli-commands.md`
-- [ ] T013 Run `npm run lint && npm test && npm run build` and confirm zero errors, zero warnings; fix any lint or type issues before marking complete
+- [x] T012 [P] Update `README.md` — add `azdo pr comments reply` and `azdo pr comment-reply` to the PR commands section with usage examples matching the contract in `contracts/cli-commands.md`
+- [x] T013 Run `npm run lint && npm test && npm run build` and confirm zero errors, zero warnings; fix any lint or type issues before marking complete
 
 ---
 

--- a/specs/029-pr-comment-reply/tasks.md
+++ b/specs/029-pr-comment-reply/tasks.md
@@ -1,0 +1,155 @@
+# Tasks: PR Comment Reply
+
+**Input**: Design documents from `/specs/029-pr-comment-reply/`  
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no shared-state dependencies)
+- **[Story]**: User story this task belongs to (US1/US2/US3)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project or dependency setup is needed (existing TypeScript/commander.js project, no new runtime deps). Single verification task.
+
+- [ ] T001 Confirm branch `029-pr-comment-reply` is checked out and up to date with `origin/029-pr-comment-reply`; run `npm install` to ensure lockfile is consistent
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: New types and service function that ALL user story phases depend on. Must complete before any command code is written.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Add `AzdoCreatedComment` and `PostedPrComment` interfaces to `src/types/pull-request.ts` (per `data-model.md` — shapes for the POST /comments API response and the CLI's mapped result type)
+- [ ] T003 [P] Add `buildThreadCommentUrl()` (internal) and `postThreadComment()` (exported) to `src/services/pr-client.ts` — POST to `/pullRequests/{prId}/threads/{threadId}/comments?api-version=7.1` with `{ content, parentCommentId: 0, commentType: 1 }`, map response to `PostedPrComment`
+- [ ] T004 [P] Add `postThreadComment()` unit tests in `tests/unit/pr-client.test.ts` — mock `fetch` to cover: success 200, auth failure 401, permission denied 403, thread not found 404, network error
+
+**Checkpoint**: `postThreadComment()` is tested and the types are in place — user story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Reply to a PR thread (Priority: P1) 🎯 MVP
+
+**Goal**: `azdo pr comments reply <threadId> "<text>"` posts a reply and prints human-readable confirmation.
+
+**Independent Test**: Run `azdo pr comments reply <threadId> "hello"` on a PR with a known thread; re-run `azdo pr comments` and confirm the reply appears in the thread listing.
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] Add `runCommentReply()` action function in `src/commands/pr.ts` — reuse `resolveThreadTarget()` for PR resolution; validate `threadIdRaw` as positive integer and `text` as non-empty (exit 1 with `Reply text must not be empty.` on failure); fetch threads with `getPullRequestThreads()` and find the target thread (exit 1 with `Thread #<id> not found on pull request #<pr>.` if missing); call `postThreadComment()`; print `Reply posted to thread #<threadId> on pull request #<prId>.\n` to stdout
+- [ ] T006 [US1] Add `createPrCommentsReplyCommand()` factory in `src/commands/pr.ts` — `new Command('reply')`, argument `<threadId>`, argument `<text>`, options `--org`, `--project`, `--pr-number` (reuse `PR_NUMBER_HELP`), action delegates to `runCommentReply()`
+- [ ] T007 [US1] Register the reply subcommand: inside `createPrCommentsCommand()` in `src/commands/pr.ts`, add `command.addCommand(createPrCommentsReplyCommand())` before `return command`
+
+**Checkpoint**: `azdo pr comments reply <threadId> "<text>"` works end-to-end on a real PR. Human-readable output only at this point.
+
+---
+
+## Phase 4: User Story 2 — JSON output for scripted use (Priority: P2)
+
+**Goal**: `azdo pr comments reply <threadId> "<text>" --json` emits `{ pullRequestId, threadId, commentId, content }`.
+
+**Independent Test**: Run with `--json`, parse stdout, confirm all four fields are present and types are correct.
+
+### Implementation for User Story 2
+
+- [ ] T008 [US2] Add `PrCommentReplyResult` local interface in `src/commands/pr.ts` — `{ pullRequestId: number; threadId: number; commentId: number; content: string }`
+- [ ] T009 [US2] Add `--json` option to `createPrCommentsReplyCommand()` in `src/commands/pr.ts`; extend `runCommentReply()` to accept `options.json` — when true, emit `JSON.stringify(result, null, 2)` to stdout instead of the human-readable line; on `--json` + error, errors still go to stderr and stdout stays empty
+
+**Checkpoint**: `azdo pr comments reply <threadId> "<text>" --json` emits the structured JSON object.
+
+---
+
+## Phase 5: User Story 3 — Alias command (Priority: P3)
+
+**Goal**: `azdo pr comment-reply <threadId> "<text>"` works identically to `azdo pr comments reply`.
+
+**Independent Test**: Run `azdo pr comment-reply <threadId> "alias test"` and verify same output as the canonical form.
+
+### Implementation for User Story 3
+
+- [ ] T010 [US3] Add `createPrCommentReplyCommand()` factory in `src/commands/pr.ts` — `new Command('comment-reply')`, identical arguments/options to `createPrCommentsReplyCommand()`, same `runCommentReply()` action, description: `'Post a reply to a pull request comment thread (alias of "azdo pr comments reply")'`
+- [ ] T011 [US3] Register alias: inside `createPrCommand()` in `src/commands/pr.ts`, add `command.addCommand(createPrCommentReplyCommand())` alongside the existing `comment-resolve` and `comment-reopen` registrations
+
+**Checkpoint**: Both `azdo pr comments reply` and `azdo pr comment-reply` work end-to-end.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, final build verification, and README update (required by constitution before merge).
+
+- [ ] T012 [P] Update `README.md` — add `azdo pr comments reply` and `azdo pr comment-reply` to the PR commands section with usage examples matching the contract in `contracts/cli-commands.md`
+- [ ] T013 Run `npm run lint && npm test && npm run build` and confirm zero errors, zero warnings; fix any lint or type issues before marking complete
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — **BLOCKS Phases 3–5**
+- **Phase 3 (US1)**: Depends on Phase 2 — core command body
+- **Phase 4 (US2)**: Depends on Phase 3 — adds `--json` to existing action
+- **Phase 5 (US3)**: Depends on Phase 3 — alias reuses the same action
+- **Phase 6 (Polish)**: Depends on Phases 3–5 complete
+
+### Within Phase 2
+
+- T003 and T004 can run in parallel (different files: `pr-client.ts` vs `pr-client.test.ts`)
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 2 only
+- **US2 (P2)**: Depends on US1 (extends the same function — must be sequential)
+- **US3 (P3)**: Depends on US1 (reuses `runCommentReply` — types must exist)
+
+---
+
+## Parallel Opportunities
+
+```bash
+# Phase 2: T003 and T004 run in parallel
+Task T003: "Add postThreadComment() to src/services/pr-client.ts"
+Task T004: "Add unit tests for postThreadComment() in tests/unit/pr-client.test.ts"
+
+# Phase 6: T012 runs in parallel with any remaining cleanup
+Task T012: "Update README.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001)
+2. Complete Phase 2: Foundational (T002–T004)
+3. Complete Phase 3: User Story 1 (T005–T007)
+4. **STOP and VALIDATE**: `azdo pr comments reply <threadId> "hello"` posts a reply
+5. Continue to US2 (JSON), US3 (alias), then Polish
+
+### Incremental Delivery
+
+1. T001–T004 → foundation ready, service tested
+2. T005–T007 → `azdo pr comments reply` works (MVP)
+3. T008–T009 → `--json` works
+4. T010–T011 → `azdo pr comment-reply` alias works
+5. T012–T013 → docs updated, build green → ready for PR
+
+---
+
+## Notes
+
+- All code in `src/commands/pr.ts` and `src/services/pr-client.ts` — no new files needed
+- `runCommentReply()` is the only new async action function; US2 and US3 extend it rather than duplicate it
+- `resolveThreadTarget()` is fully reused — no modification needed
+- `handlePrCommandError(err, context, 'write')` handles all network/auth/server errors
+- `parsePositivePrNumber()` is reused for threadId validation (already validates positive integers)
+- `configureUnwrappedHelp()` must be applied to both new commands

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -20,6 +20,7 @@ import {
   getPullRequestById,
   isThreadResolved,
   patchThreadStatus,
+  postThreadComment,
 } from '../services/pr-client.js';
 import { requireAuthCredential } from '../services/auth.js';
 import { resolveContext } from '../services/context.js';
@@ -547,6 +548,7 @@ export function createPrCommentsCommand(): Command {
       }
     });
 
+  command.addCommand(createPrCommentsReplyCommand());
   return command;
 }
 
@@ -725,6 +727,100 @@ export function createPrCommentReopenCommand(): Command {
   return command;
 }
 
+// Flat JSON shape emitted by `azdo pr comments reply --json` and its alias.
+interface PrCommentReplyResult {
+  pullRequestId: number;
+  threadId: number;
+  commentId: number;
+  content: string;
+}
+
+async function runCommentReply(
+  threadIdRaw: string,
+  text: string,
+  options: PrCommandOptions,
+): Promise<void> {
+  let context: AzdoContext | undefined;
+
+  try {
+    const trimmedText = text.trim();
+    if (!trimmedText) {
+      writeError('Reply text must not be empty.');
+      return;
+    }
+
+    const target = await resolveThreadTarget(threadIdRaw, options);
+    if (target === null) {
+      return;
+    }
+    context = target.context;
+
+    const threads = await getPullRequestThreads(target.context, target.repo, target.pat, target.pullRequest.id);
+    const thread = threads.find((t) => t.id === target.threadId);
+    if (!thread) {
+      writeError(`Thread #${target.threadId} not found on pull request #${target.pullRequest.id}.`);
+      return;
+    }
+
+    const posted = await postThreadComment(
+      target.context,
+      target.repo,
+      target.pat,
+      target.pullRequest.id,
+      target.threadId,
+      trimmedText,
+    );
+
+    const result: PrCommentReplyResult = {
+      pullRequestId: target.pullRequest.id,
+      threadId: target.threadId,
+      commentId: posted.id,
+      content: posted.content,
+    };
+
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return;
+    }
+
+    process.stdout.write(`Reply posted to thread #${target.threadId} on pull request #${target.pullRequest.id}.\n`);
+  } catch (err) {
+    handlePrCommandError(err, context, 'write');
+  }
+}
+
+export function createPrCommentsReplyCommand(): Command {
+  const command = new Command('reply');
+  configureUnwrappedHelp(command)
+    .description('Post a reply to a pull request comment thread')
+    .argument('<threadId>', 'numeric id of the thread to reply to')
+    .argument('<text>', 'text of the reply')
+    .option('--org <org>', 'Azure DevOps organization')
+    .option('--project <project>', 'Azure DevOps project')
+    .option('--pr-number <N>', PR_NUMBER_HELP)
+    .option('--json', 'output JSON')
+    .action(async (threadIdRaw: string, text: string, options: PrCommandOptions) => {
+      await runCommentReply(threadIdRaw, text, options);
+    });
+  return command;
+}
+
+export function createPrCommentReplyCommand(): Command {
+  const command = new Command('comment-reply');
+  configureUnwrappedHelp(command)
+    .description('Post a reply to a pull request comment thread (alias of "azdo pr comments reply")')
+    .argument('<threadId>', 'numeric id of the thread to reply to')
+    .argument('<text>', 'text of the reply')
+    .option('--org <org>', 'Azure DevOps organization')
+    .option('--project <project>', 'Azure DevOps project')
+    .option('--pr-number <N>', PR_NUMBER_HELP)
+    .option('--json', 'output JSON')
+    .action(async (threadIdRaw: string, text: string, options: PrCommandOptions) => {
+      await runCommentReply(threadIdRaw, text, options);
+    });
+  return command;
+}
+
 export function createPrCommand(): Command {
   const command = new Command('pr');
   command.description('Manage Azure DevOps pull requests');
@@ -733,5 +829,6 @@ export function createPrCommand(): Command {
   command.addCommand(createPrCommentsCommand());
   command.addCommand(createPrCommentResolveCommand());
   command.addCommand(createPrCommentReopenCommand());
+  command.addCommand(createPrCommentReplyCommand());
   return command;
 }

--- a/src/services/pr-client.ts
+++ b/src/services/pr-client.ts
@@ -4,6 +4,7 @@ import type { AzdoBuild, AzdoBuildListResponse } from '../types/pipeline.js';
 import type {
   ActiveCommentThread,
   ActivePullRequestComment,
+  AzdoCreatedComment,
   AzdoPolicyEvaluation,
   AzdoPolicyEvaluationListResponse,
   AzdoPrListResponse,
@@ -14,6 +15,7 @@ import type {
   AzdoThread,
   AzdoThreadListResponse,
   BranchPullRequestMatch,
+  PostedPrComment,
   PullRequestCheck,
   PullRequestOpenRequest,
   PullRequestOpenResult,
@@ -492,4 +494,37 @@ export async function getPullRequestThreads(
   return data.value
     .map(mapThread)
     .filter((thread): thread is ActiveCommentThread => thread !== null);
+}
+
+function buildThreadCommentUrl(context: AzdoContext, repo: string, prId: number, threadId: number): URL {
+  const url = new URL(
+    `https://dev.azure.com/${encodeURIComponent(context.org)}/${encodeURIComponent(context.project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullRequests/${prId}/threads/${threadId}/comments`,
+  );
+  url.searchParams.set('api-version', '7.1');
+  return url;
+}
+
+export async function postThreadComment(
+  context: AzdoContext,
+  repo: string,
+  cred: AuthCredential,
+  prId: number,
+  threadId: number,
+  content: string,
+): Promise<PostedPrComment> {
+  const response = await fetchWithErrors(buildThreadCommentUrl(context, repo, prId, threadId).toString(), {
+    method: 'POST',
+    headers: {
+      ...authHeaders(cred),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ content, parentCommentId: 0, commentType: 1 }),
+  });
+  const data = await readJsonResponse<AzdoCreatedComment>(response);
+  return {
+    id: data.id,
+    author: data.author?.displayName ?? null,
+    content: data.content ?? content,
+    publishedAt: data.publishedDate ?? null,
+  };
 }

--- a/src/types/pull-request.ts
+++ b/src/types/pull-request.ts
@@ -171,6 +171,25 @@ export interface AzdoPullRequestStatus {
   targetUrl?: string;
 }
 
+// Minimal shape of the POST /threads/{id}/comments 200 response. Only the
+// fields the CLI reads are declared; the ADO API returns many more.
+export interface AzdoCreatedComment {
+  id: number;
+  author?: { displayName?: string };
+  content?: string;
+  publishedDate?: string;
+}
+
+// Result of a successful postThreadComment() call — mapped from the ADO
+// response and exposed to command code. Mirrors ActivePullRequestComment
+// in nullability convention.
+export interface PostedPrComment {
+  id: number;
+  author: string | null;
+  content: string;
+  publishedAt: string | null;
+}
+
 // Minimal shape of the Projects API response — we only need the GUID to build
 // the policy-evaluation artifactId.
 export interface AzdoProject {

--- a/tests/unit/pr-client.test.ts
+++ b/tests/unit/pr-client.test.ts
@@ -736,7 +736,7 @@ describe('pr-client', () => {
           content: 'Great suggestion!',
           publishedDate: '2026-06-15T13:00:00.000Z',
         }),
-      } as Response);
+      });
 
       const result = await postThreadComment(context, 'repo-name', 'pat', 22, 148, 'Great suggestion!');
 
@@ -761,7 +761,7 @@ describe('pr-client', () => {
         ok: true,
         status: 200,
         json: async () => ({ id: 5, content: 'reply text' }),
-      } as Response);
+      });
 
       const result = await postThreadComment(context, 'repo-name', 'pat', 22, 148, 'reply text');
       expect(result.author).toBeNull();
@@ -770,12 +770,12 @@ describe('pr-client', () => {
     });
 
     it('throws AUTH_FAILED on a 401 response', async () => {
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 401 } as Response);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 401 });
       await expect(postThreadComment(context, 'repo-name', 'pat', 22, 148, 'hi')).rejects.toThrow('AUTH_FAILED');
     });
 
     it('throws PERMISSION_DENIED on a 403 response', async () => {
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 403 } as Response);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 403 });
       await expect(postThreadComment(context, 'repo-name', 'pat', 22, 148, 'hi')).rejects.toThrow('PERMISSION_DENIED');
     });
 
@@ -785,7 +785,7 @@ describe('pr-client', () => {
         status: 404,
         text: async () => '',
         headers: { get: () => null },
-      } as unknown as Response);
+      });
       await expect(postThreadComment(context, 'repo-name', 'pat', 22, 148, 'hi')).rejects.toThrow(/NOT_FOUND/);
     });
 

--- a/tests/unit/pr-client.test.ts
+++ b/tests/unit/pr-client.test.ts
@@ -9,6 +9,7 @@ import {
   listPullRequests,
   openPullRequest,
   patchThreadStatus,
+  postThreadComment,
   resolveProjectId,
 } from '../../src/services/pr-client.js';
 
@@ -721,6 +722,76 @@ describe('pr-client', () => {
       const result = await getPullRequestThreads(context, 'repo-name', 'pat', 42);
       expect(result[0].threadContext).toBeNull();
       expect(result[0].line).toBeNull();
+    });
+  });
+
+  describe('postThreadComment', () => {
+    it('posts a reply and maps the response to PostedPrComment', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 3,
+          author: { displayName: 'Alice' },
+          content: 'Great suggestion!',
+          publishedDate: '2026-06-15T13:00:00.000Z',
+        }),
+      } as Response);
+
+      const result = await postThreadComment(context, 'repo-name', 'pat', 22, 148, 'Great suggestion!');
+
+      expect(result).toEqual({
+        id: 3,
+        author: 'Alice',
+        content: 'Great suggestion!',
+        publishedAt: '2026-06-15T13:00:00.000Z',
+      });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/pullRequests/22/threads/148/comments'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ content: 'Great suggestion!', parentCommentId: 0, commentType: 1 }),
+          headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+        }),
+      );
+    });
+
+    it('returns null author and publishedAt when omitted from response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 5, content: 'reply text' }),
+      } as Response);
+
+      const result = await postThreadComment(context, 'repo-name', 'pat', 22, 148, 'reply text');
+      expect(result.author).toBeNull();
+      expect(result.publishedAt).toBeNull();
+      expect(result.content).toBe('reply text');
+    });
+
+    it('throws AUTH_FAILED on a 401 response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 401 } as Response);
+      await expect(postThreadComment(context, 'repo-name', 'pat', 22, 148, 'hi')).rejects.toThrow('AUTH_FAILED');
+    });
+
+    it('throws PERMISSION_DENIED on a 403 response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 403 } as Response);
+      await expect(postThreadComment(context, 'repo-name', 'pat', 22, 148, 'hi')).rejects.toThrow('PERMISSION_DENIED');
+    });
+
+    it('throws NOT_FOUND on a 404 response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: async () => '',
+        headers: { get: () => null },
+      } as unknown as Response);
+      await expect(postThreadComment(context, 'repo-name', 'pat', 22, 148, 'hi')).rejects.toThrow(/NOT_FOUND/);
+    });
+
+    it('throws NETWORK_ERROR on a network failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('fetch failed'));
+      await expect(postThreadComment(context, 'repo-name', 'pat', 22, 148, 'hi')).rejects.toThrow('NETWORK_ERROR');
     });
   });
 });


### PR DESCRIPTION
<!-- speckit:handoff-to-pr:a4f9c2e1-8b3d-4f6a-9e5c-d2b7e8a1f0c4 -->

Closes #65

## Summary

Adds `azdo pr comments reply <threadId> "<text>"` (and the flat alias `azdo pr comment-reply`) to post a new text comment into an existing pull request thread via the ADO REST API.

Fills the read/write gap in the PR comments surface: the CLI could already list threads but had no way to respond to reviewer feedback programmatically.

## What's Changed

- New types: `AzdoCreatedComment`, `PostedPrComment` in `src/types/pull-request.ts`
- New service function: `postThreadComment()` in `src/services/pr-client.ts`
- New commands: `azdo pr comments reply` (canonical) + `azdo pr comment-reply` (alias) in `src/commands/pr.ts`
- New unit tests for `postThreadComment()` in `tests/unit/pr-client.test.ts`

## Test plan

- [ ] `azdo pr comments reply <threadId> "hello"` posts to a real PR thread
- [ ] `azdo pr comments reply <threadId> "hello" --json` emits `{ pullRequestId, threadId, commentId, content }`
- [ ] `azdo pr comment-reply <threadId> "alias test"` produces identical output
- [ ] Empty text → `Reply text must not be empty.` on stderr, exit 1
- [ ] Invalid threadId → `Invalid thread id "x"; expected a positive integer.`, exit 1
- [ ] Non-existent threadId → `Thread #<id> not found on pull request #<pr>.`, exit 1
- [ ] Unit tests pass: `npm test`
- [ ] Lint clean: `npm run lint`
- [ ] Build succeeds: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)