### PR TITLE
feat(#68): add azdo auth diagnose command and --trace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Azure DevOps CLI focused on work item read/write workflows.
 - Check branch pull request status, open PRs to `develop`, list PR comment threads for any PR (`--pr-number`), and resolve/reopen threads from the CLI (`pr`)
 - Persist org/project/default fields in local config (`config`)
 - List all fields of a work item (`list-fields`)
-- Authenticate per Azure DevOps organization with `azdo auth login` — OAuth (Microsoft Entra) by default, or a Personal Access Token via `--use-pat` (or the `AZDO_PAT` env var). Credentials are stored in the OS credential store. Inspect with `azdo auth status`, remove with `azdo auth logout`. See [docs/authentication.md](docs/authentication.md).
+- Authenticate per Azure DevOps organization with `azdo auth login` — OAuth (Microsoft Entra) by default, or a Personal Access Token via `--use-pat` (or the `AZDO_PAT` env var). Credentials are stored in the OS credential store. Inspect with `azdo auth status`, remove with `azdo auth logout`. Diagnose auth problems with `azdo auth diagnose`. See [docs/authentication.md](docs/authentication.md).
+- Trace all HTTP requests to a local file with `--trace <filepath>` (sensitive headers and tokens are automatically redacted).
 
 ## Installation
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,6 +20,7 @@
 | `azdo auth` | Legacy PAT-prompt entry point (back-compat alias of `azdo auth login --use-pat`) | `--org`, `--from-stdin`, `--no-browser` |
 | `azdo auth status` | Report stored credentials (kind `pat`/`oauth`, org, account/expiry, backend) — never the token | `--org`, `--json` |
 | `azdo auth logout` | Remove the stored credential (PAT or OAuth) for an org, or every org with `--all` | `--org`, `--all` |
+| `azdo auth diagnose` | Show auth type, credential source, org, and live connectivity test result | `--org`, `--project`, `--json` |
 | `azdo clear-pat` | **Deprecated** alias for `azdo auth logout` | `--org` |
 
 ---

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "format": "prettier --check src/",
-    "test": "npm run build && vitest run tests/unit tests/integration",
-    "test:unit": "npm run build && vitest run tests/unit",
+    "test": "npm run typecheck && npm run lint && npm run build && vitest run tests/unit tests/integration",
+    "test:unit": "npm run typecheck && npm run lint && npm run build && vitest run tests/unit",
     "test:integration": "npm run build && vitest run tests/integration",
     "test:integration:full": "bash scripts/setup-keyring.sh && npm run test:integration"
   },

--- a/specs/030-auth-diagnostics/checklists/requirements.md
+++ b/specs/030-auth-diagnostics/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Auth Diagnostics
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/030-auth-diagnostics/contracts/auth-diagnose-cli.md
+++ b/specs/030-auth-diagnostics/contracts/auth-diagnose-cli.md
@@ -1,0 +1,65 @@
+# Contract: `azdo auth diagnose`
+
+## Synopsis
+
+```
+azdo auth diagnose [--org <name>] [--project <name>] [--json]
+```
+
+## Output (human-readable, default)
+
+```
+Auth type:   PAT
+Source:      credential-store
+Org:         myorg
+Project:     (not set)
+Connectivity: OK
+```
+
+On failure:
+
+```
+Auth type:   PAT
+Source:      credential-store
+Org:         myorg
+Project:     (not set)
+Connectivity: FAILED
+Error:       TF400813: The user 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' is not authorized to access this resource.
+```
+
+No credentials found:
+
+```
+Auth type:   none
+Source:      (none)
+Org:         myorg
+Connectivity: no credentials found
+```
+
+## Output (--json)
+
+```json
+{
+  "authType": "pat",
+  "credentialSource": "credential-store",
+  "org": "myorg",
+  "project": null,
+  "connectivityStatus": "ok",
+  "connectivityError": null
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Connectivity OK (or no credentials but command itself ran) |
+| 1 | Connectivity FAILED or unexpected error |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--org <name>` | Override org (default: context resolution) |
+| `--project <name>` | Override project (default: context resolution) |
+| `--json` | Emit JSON instead of human-readable text |

--- a/specs/030-auth-diagnostics/contracts/trace-flag-cli.md
+++ b/specs/030-auth-diagnostics/contracts/trace-flag-cli.md
@@ -1,0 +1,40 @@
+# Contract: Global `--trace <filepath>` flag
+
+## Synopsis
+
+```
+azdo --trace <filepath> <command> [options]
+```
+
+## Behaviour
+
+- Appends one entry per HTTP request/response to `<filepath>`.
+- File is created if it does not exist, with owner-only permissions (Unix: `0600`).
+- If the file cannot be opened, a warning is printed to stderr and the command continues normally (non-fatal).
+- No trace file is created when `--trace` is omitted.
+
+## Entry format
+
+Each entry is a JSON object on one line (NDJSON), followed by a blank line separator:
+
+```
+{"timestamp":"2026-06-15T19:00:00.000Z","method":"GET","url":"https://dev.azure.com/myorg/_apis/projects?api-version=7.1&$top=1","requestHeaders":{"Authorization":"[REDACTED]","Content-Type":"application/json"},"requestBody":null,"responseStatus":200,"responseHeaders":{"content-type":"application/json; charset=utf-8"},"responseBody":"{\"count\":3,\"value\":[...]}"}
+
+```
+
+## Redaction guarantee
+
+- `Authorization` header value → `[REDACTED]`
+- Any header matching `/^x-.*token$/i` → `[REDACTED]`
+- URL query params `token` or `pat` → `[REDACTED]`
+- JSON body top-level fields `token`, `accessToken`, `pat` → `[REDACTED]`
+
+## Examples
+
+```bash
+# Trace a failing work-item fetch
+azdo --trace /tmp/azdo-trace.log get-item 12345
+
+# Trace auth diagnose
+azdo --trace ./debug.log auth diagnose --org myorg
+```

--- a/specs/030-auth-diagnostics/data-model.md
+++ b/specs/030-auth-diagnostics/data-model.md
@@ -1,0 +1,37 @@
+# Data Model: Auth Diagnostics
+
+## AuthDiagnosticReport
+
+The structured result of `azdo auth diagnose`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `authType` | `'pat' \| 'oauth' \| 'none'` | Active credential kind |
+| `credentialSource` | `string \| null` | Where the credential was loaded from (e.g. `'env:AZDO_PAT'`, `'credential-store'`, `null` if none found) |
+| `org` | `string` | Configured Azure DevOps organisation |
+| `project` | `string \| null` | Configured project (if set) |
+| `connectivityStatus` | `'ok' \| 'failed' \| 'no-credentials'` | Result of the scope-aware connectivity test |
+| `connectivityError` | `string \| null` | Exact API error message when `connectivityStatus` is `'failed'`; `null` otherwise |
+
+## TraceEntry
+
+One HTTP exchange written to the trace log.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | `string` | ISO-8601 UTC timestamp of the request |
+| `method` | `string` | HTTP method (e.g. `GET`, `POST`) |
+| `url` | `string` | Full request URL |
+| `requestHeaders` | `Record<string, string>` | Request headers with credential values replaced by `[REDACTED]` |
+| `requestBody` | `string \| null` | Request body text (or `null` if absent) |
+| `responseStatus` | `number` | HTTP response status code |
+| `responseHeaders` | `Record<string, string>` | Response headers |
+| `responseBody` | `string` | Response body text |
+
+### Redaction rules
+
+The following values are replaced with `[REDACTED]` before writing:
+- `Authorization` header value (any scheme)
+- Any header whose name matches `/^x-.*token$/i`
+- Any URL query parameter named `token` or `pat`
+- Any JSON body field named `token`, `accessToken`, or `pat` (top-level only)

--- a/specs/030-auth-diagnostics/plan.md
+++ b/specs/030-auth-diagnostics/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Auth Diagnostics
+
+**Branch**: `030-auth-diagnostics` | **Date**: 2026-06-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/030-auth-diagnostics/spec.md`
+
+## Summary
+
+Add `azdo auth diagnose` — a scope-aware connectivity test that surfaces auth type, credential source, org, and the exact ADO API error — plus a global `--trace <filepath>` flag that appends redacted HTTP request/response entries to a file for offline debugging.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict)
+**Primary Dependencies**: commander.js, native `fetch`, Node.js `fs` (file permissions)
+**Storage**: Append-only local file (trace log); no new persistent state
+**Testing**: vitest
+**Target Platform**: Node.js LTS (cross-platform; file permission restriction is Unix/macOS only)
+**Project Type**: CLI tool
+**Performance Goals**: `auth diagnose` completes in under 5 seconds (SC-002)
+**Constraints**: Zero new runtime dependencies; cross-platform
+**Scale/Scope**: Single-user CLI; trace file grows per-invocation
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First Design | ✅ | `azdo auth diagnose` is a proper subcommand; `--trace` is a POSIX-style flag; errors to stderr |
+| II. TypeScript Strictness | ✅ | No `any`; `AuthDiagnosticReport` and `TraceEntry` interfaces fully typed |
+| III. Single Responsibility | ✅ | Diagnose logic in `auth-diagnostics.ts`; trace logic in `trace-writer.ts` |
+| IV. npm Distribution | ✅ | No new runtime deps; bundled via tsup |
+| V. Simplicity | ✅ | Thin wrappers; no new abstractions beyond what FR requires |
+| VI. ADO API Research | ✅ | Connectivity test uses `GET /_apis/projects?$top=1&api-version=7.1` (scope-aware, read-only) |
+
+No gate violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-auth-diagnostics/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── auth-diagnose-cli.md
+│   └── trace-flag-cli.md
+└── tasks.md             # Phase 2 output (speckit-tasks)
+```
+
+### Source Code Changes
+
+```text
+src/
+├── commands/
+│   └── auth.ts                   # ADD createAuthDiagnoseCommand(); register as subcommand
+├── services/
+│   ├── auth.ts                   # ADD diagnoseAuth() — calls resolveAuthCredential + connectivity test
+│   ├── auth-diagnostics.ts       # NEW — runConnectivityTest(), formatDiagnosticReport()
+│   ├── azdo-client.ts            # MODIFY fetchWithErrors() — accept optional TraceWriter param
+│   └── trace-writer.ts           # NEW — TraceWriter class, singleton, redaction logic
+├── types/
+│   └── auth-diagnostics.ts       # NEW — AuthDiagnosticReport, TraceEntry interfaces
+└── index.ts                      # ADD --trace global option; init TraceWriter singleton
+
+tests/unit/
+├── auth-diagnostics.test.ts      # NEW — unit tests for diagnoseAuth, connectivity, formatting
+└── trace-writer.test.ts          # NEW — unit tests for redaction, file creation, append
+```
+
+**Structure Decision**: Single-project flat layout, consistent with all existing features.
+
+## Implementation Notes
+
+### `azdo auth diagnose` flow
+
+1. Resolve org via normal context resolution (`resolveContext`)
+2. Call `resolveAuthCredential(org)` — returns `{ kind, source, pat }` or `null`
+3. If `null`: print "Auth type: none / Source: (none) / Connectivity: no credentials found"; exit 0
+4. POST to `GET https://dev.azure.com/{org}/_apis/projects?api-version=7.1&$top=1` with resolved credential
+5. On success (2xx): print `Connectivity: OK`
+6. On failure: catch the raw HTTP response (bypass `fetchWithErrors` error mapping to get real message), print `Connectivity: FAILED\nError: <body.message>`
+7. Exit 0 on OK, 1 on FAILED
+
+### Connectivity test — raw error surfacing
+
+`fetchWithErrors` currently maps 401 → `AUTH_FAILED` etc., discarding the body. The diagnose command needs the raw ADO error message. Solution: add a thin `fetchRaw()` (or call native `fetch` directly in `auth-diagnostics.ts`) that returns the status + body without throwing, used only for the connectivity probe.
+
+### `--trace` wiring
+
+- `src/index.ts`: `program.option('--trace <filepath>', 'append HTTP request/response log to file')` before `program.parse()`
+- After parse: `const tracePath = program.opts().trace; if (tracePath) initTraceWriter(tracePath);`
+- `initTraceWriter` opens the file (`fs.open`, mode `0o600`), sets the module-level `TraceWriter` singleton
+- `fetchWithErrors` checks `getActiveTraceWriter()` and appends an entry after each response
+
+### Redaction in TraceWriter
+
+- Authorization header → `[REDACTED]`
+- Headers matching `/^x-.*token$/i` → `[REDACTED]`
+- URL query params `token`, `pat` → `[REDACTED]`
+- JSON body top-level `token`, `accessToken`, `pat` fields → `[REDACTED]` (best-effort; non-JSON bodies untouched)
+
+### File permissions (FR-008)
+
+```typescript
+// Unix only — Windows ignores the mode argument
+fs.open(filepath, 'a', 0o600, (err, fd) => { ... })
+```
+
+Document in help text that trace files are created owner-only on Unix/macOS; Windows users should restrict access via NTFS ACLs if needed.
+
+## ADO API — Connectivity Test Endpoint
+
+`GET https://dev.azure.com/{org}/_apis/projects?api-version=7.1&$top=1`
+
+- **Auth required**: Yes (401 for invalid credentials)
+- **Scope required**: Project and Team (read) — validates PAT scope
+- **Response on success**: `{ count: N, value: [...] }` (200)
+- **Response on auth failure**: `{ message: "TF400813: ..." }` (401/403)
+- **Side effects**: None (read-only)

--- a/specs/030-auth-diagnostics/pr-report.md
+++ b/specs/030-auth-diagnostics/pr-report.md
@@ -1,0 +1,26 @@
+# PR Report: Auth Diagnostics
+
+**Branch**: `030-auth-diagnostics`
+**Date**: 2026-06-15
+**Spec**: [specs/030-auth-diagnostics/spec.md](../030-auth-diagnostics/spec.md)
+
+## Summary
+
+Adds `azdo auth diagnose` — a scope-aware connectivity test that surfaces auth type, credential source, configured org, and the exact Azure DevOps API error when authentication fails. Also adds a global `--trace <filepath>` flag that appends redacted HTTP request/response entries to a local file for offline debugging of API communication failures.
+
+## What's New
+
+- **`src/types/auth-diagnostics.ts`**: New `AuthDiagnosticReport` and `TraceEntry` interfaces.
+- **`src/services/auth-diagnostics.ts`**: `runConnectivityTest()` (scope-aware probe via `GET /_apis/projects?$top=1`), `diagnoseAuth()`, and `formatDiagnosticReport()`.
+- **`src/services/trace-writer.ts`**: `TraceWriter` class with append mode, `0o600` file permissions (Unix), and credential redaction; module-level singleton.
+- **`src/commands/auth.ts`**: `createAuthDiagnoseCommand()` registered as `azdo auth diagnose` subcommand with `--org`, `--project`, `--json` options.
+- **`src/services/azdo-client.ts`**: `fetchRaw()` helper (returns raw status + body without throwing); `fetchWithErrors()` hooks into `TraceWriter` singleton when active.
+- **`src/index.ts`**: `--trace <filepath>` global option wired to `initTraceWriter()`.
+
+## Breaking Changes
+
+None — `auth diagnose` and `--trace` are purely additive.
+
+## Testing
+
+*(To be updated after implementation)*

--- a/specs/030-auth-diagnostics/quickstart.md
+++ b/specs/030-auth-diagnostics/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart: Auth Diagnostics
+
+## Scenario 1 — Diagnose a failing PAT
+
+```bash
+# Store a PAT (or it may already be stored from a previous auth)
+azdo auth login --org myorg --use-pat
+
+# Run the diagnostic
+azdo auth diagnose --org myorg
+```
+
+Expected output when PAT scope is wrong:
+```
+Auth type:   PAT
+Source:      credential-store
+Org:         myorg
+Project:     (not set)
+Connectivity: FAILED
+Error:       TF400813: The user '...' is not authorized to access this resource.
+```
+
+Expected output when PAT is valid:
+```
+Auth type:   PAT
+Source:      credential-store
+Org:         myorg
+Project:     (not set)
+Connectivity: OK
+```
+
+## Scenario 2 — Diagnose with environment variable PAT
+
+```bash
+export AZDO_PAT=mypatvalue
+azdo auth diagnose --org myorg
+```
+
+Expected output:
+```
+Auth type:   PAT
+Source:      env:AZDO_PAT
+Org:         myorg
+Project:     (not set)
+Connectivity: OK   # or FAILED with error detail
+```
+
+## Scenario 3 — No credentials stored
+
+```bash
+azdo auth diagnose --org myorg
+```
+
+Expected output (exit code 0, no crash):
+```
+Auth type:   none
+Source:      (none)
+Org:         myorg
+Connectivity: no credentials found
+```
+
+## Scenario 4 — Trace a command to investigate API errors
+
+```bash
+# Run a failing command with full HTTP trace
+azdo --trace /tmp/azdo-trace.log get-item 44119
+
+# Inspect the trace (credentials are redacted)
+cat /tmp/azdo-trace.log
+```
+
+Expected trace file content (excerpt):
+```json
+{"timestamp":"2026-06-15T19:00:00.000Z","method":"GET","url":"https://dev.azure.com/myorg/myproject/_apis/wit/workitems/44119?api-version=7.1","requestHeaders":{"Authorization":"[REDACTED]"},"requestBody":null,"responseStatus":401,"responseHeaders":{},"responseBody":"{\"$id\":\"1\",\"innerException\":null,\"message\":\"TF400813...\"}"}
+```
+
+## Scenario 5 — JSON output for scripting
+
+```bash
+azdo auth diagnose --org myorg --json
+```
+
+Expected output:
+```json
+{
+  "authType": "pat",
+  "credentialSource": "credential-store",
+  "org": "myorg",
+  "project": null,
+  "connectivityStatus": "failed",
+  "connectivityError": "TF400813: The user '...' is not authorized to access this resource."
+}
+```

--- a/specs/030-auth-diagnostics/research.md
+++ b/specs/030-auth-diagnostics/research.md
@@ -1,0 +1,51 @@
+# Research: Auth Diagnostics
+
+## 1. Credential Source — existing `resolveAuthCredential` shape
+
+**Decision**: Reuse `resolveAuthCredential()` in `src/services/auth.ts` directly.
+
+The function already returns `{ pat, source, kind }` where:
+- `source` ∈ `'env' | 'credential-store'` — maps to human-readable "Environment variable (AZDO_PAT)" or "OS credential store"
+- `kind` ∈ `'pat' | 'oauth'` — maps to "PAT" or "OAuth"
+
+No new data-fetching needed; diagnose just calls this and formats the result.
+
+**Rationale**: Avoids duplicating credential-resolution logic; the diagnose command is a consumer of the existing auth service, not a reimplementation.
+
+## 2. Connectivity Test Endpoint
+
+**Decision**: `GET https://dev.azure.com/{org}/_apis/projects?api-version=7.1&$top=1`
+
+**Rationale**:
+- Requires authentication → catches invalid/expired credentials
+- Requires the "Project and Team (read)" scope → catches under-scoped PATs (the most common failure mode per issue #68)
+- Returns a small payload (`$top=1`) — fast and low-bandwidth
+- No side effects (read-only)
+- Available in every ADO org regardless of project configuration
+
+**Alternatives considered**:
+- `/_apis/connectionData` — auth-only, does NOT validate PAT scope; rejected because the user's problem was scope, not just connectivity
+- `/_apis/profile/me` — profile API, not always available for PAT auth on org-scoped tokens; rejected for inconsistency
+- Per-scope matrix test (C from clarify) — expensive, complex; rejected by owner (chose B)
+
+## 3. Trace Log Architecture
+
+**Decision**: Thin `TraceWriter` class in `src/services/trace-writer.ts`; `fetchWithErrors` in `src/services/azdo-client.ts` gains an optional `TraceWriter | null` parameter; a module-level singleton is set when `--trace` is parsed at startup.
+
+**Rationale**: Keeps `fetchWithErrors` as the single HTTP gateway — all HTTP traffic flows through it already. Adding a trace parameter avoids wrapping `fetch` globally (which would catch non-ADO requests on future additions).
+
+**Alternatives considered**:
+- Monkey-patching global `fetch` — would catch all fetches including OAuth token refresh calls; overly broad and harder to test
+- Passing trace path through `AzdoContext` — would require modifying every call site; rejected (YAGNI)
+
+## 4. File Permissions (FR-008)
+
+**Decision**: Create trace file with `fs.open(path, 'a', 0o600, ...)` (owner read/write only on Unix). On Windows, NTFS ACLs are not set programmatically — document that restrictive-mode behavior is Unix/macOS only; Windows defaults to the user's standard ACL which is already user-scoped in most environments.
+
+**Rationale**: Consistent with how `.env` files and SSH keys are handled. The `0o600` mode is the de-facto standard for secrets-adjacent files in Unix tooling.
+
+## 5. Global `--trace` Flag Wiring
+
+**Decision**: Register `--trace <filepath>` on the root `program` Command in `src/index.ts`. Parse it via `program.opts()` before action handlers run, initialise the `TraceWriter` singleton, and pass it into the service layer via a module-level export from `trace-writer.ts`.
+
+**Rationale**: Commander.js root options are available to all subcommands without threading the value through every command's options object. This is the same pattern used for other global flags in the codebase.

--- a/specs/030-auth-diagnostics/spec.md
+++ b/specs/030-auth-diagnostics/spec.md
@@ -53,11 +53,12 @@ A developer passes a global `--trace <file>` flag to any `azdo` command to write
 ### Functional Requirements
 
 - **FR-001**: The CLI MUST provide an `azdo auth diagnose` subcommand that prints the active auth type (PAT or OAuth), the credential source location, the configured org, and the result of a live Azure DevOps connectivity test.
-- **FR-002**: The connectivity test in `auth diagnose` MUST include the exact API error message returned by Azure DevOps when authentication fails, not a generic CLI-level message.
+- **FR-002**: The connectivity test MUST be scope-aware: it MUST attempt a minimal scoped operation (e.g. listing projects) to verify both that credentials are accepted AND that the PAT has sufficient scope — not merely that the server responded. The exact API error message MUST be surfaced when either check fails.
 - **FR-003**: The CLI MUST accept a global `--trace <filepath>` flag on any command that writes HTTP request and response details to the specified file.
 - **FR-004**: The trace log MUST redact all credential values (PAT strings, Bearer tokens, Basic auth header values) replacing them with `[REDACTED]` before writing to disk.
 - **FR-005**: The `auth diagnose` command MUST exit with a non-zero code when the connectivity test fails.
 - **FR-006**: The `--trace` flag failure to open the output file MUST be non-fatal — the command continues and prints a warning to stderr.
+- **FR-008**: The trace file MUST be created with owner-only permissions (readable and writable only by the current user) to protect potentially sensitive API response bodies.
 - **FR-007**: The `auth diagnose` output MUST be human-readable plain text by default; a `--json` flag MAY be supported for machine-readable output.
 
 ### Key Entities
@@ -89,3 +90,5 @@ A developer passes a global `--trace <file>` flag to any `azdo` command to write
 
 - Q: Should `auth diagnose` follow normal context resolution (env vars → config → flags)? → A: Yes, same as all other commands; `--org` and `--project` overrides work if provided.
 - Q: Should the trace log append or overwrite? → A: Append, so multiple invocations in a debugging session accumulate in one file.
+- Q: Should the connectivity test be auth-only or scope-aware? → A: Scope-aware (Option B) — attempt a minimal scoped operation (e.g. list projects) to verify both auth and PAT scope validity.
+- Q: Should the trace file use restrictive or default permissions? → A: Owner-only (Option A) — trace file is readable/writable only by the creating user to protect API response bodies.

--- a/specs/030-auth-diagnostics/spec.md
+++ b/specs/030-auth-diagnostics/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Auth Diagnostics
+
+**Feature Branch**: `030-auth-diagnostics`
+**Created**: 2026-06-15
+**Status**: Draft
+**Input**: User description: "Help diagnostic for auth and path — auth diagnostics command"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Auth Diagnose Command (Priority: P1)
+
+A developer runs `azdo auth diagnose` to understand why their PAT authentication is failing. The command prints the active auth method, the credential source, the org and project in use, and the result of a live connectivity test including the exact API error message.
+
+**Why this priority**: Auth failures are a blocking problem. Without a way to see the actual error, users cannot self-serve and must file support requests. This is the core diagnostic capability.
+
+**Independent Test**: Can be tested by running `azdo auth diagnose` against a known-good and a known-bad PAT and verifying the output fields and connectivity test result independently.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid PAT is stored, **When** the user runs `azdo auth diagnose`, **Then** the output shows auth type "PAT", the credential source (e.g. "windows-credential-manager"), the org name, and "Connectivity: OK".
+2. **Given** an expired or invalid PAT is stored, **When** the user runs `azdo auth diagnose`, **Then** the output shows auth type, credential source, org, and "Connectivity: FAILED — <exact API error message>".
+3. **Given** an OAuth token is active, **When** the user runs `azdo auth diagnose`, **Then** the output shows auth type "OAuth", the token source, org, and connectivity result.
+4. **Given** no credentials are stored for the configured org, **When** the user runs `azdo auth diagnose`, **Then** the output clearly states no credentials found and exits with a non-zero code.
+
+---
+
+### User Story 2 - HTTP Request/Response Trace Log (Priority: P2)
+
+A developer passes a global `--trace <file>` flag to any `azdo` command to write a redacted log of all HTTP requests and responses to a local file, enabling offline investigation of API communication failures.
+
+**Why this priority**: Some auth failures manifest as unusual HTTP responses (wrong status codes, redirect loops, malformed tokens). A trace log lets advanced users inspect the actual API traffic without needing a network proxy.
+
+**Independent Test**: Can be tested by running any `azdo` command with `--trace /tmp/trace.log` and verifying the log file is created with request/response entries and no Authorization header values present.
+
+**Acceptance Scenarios**:
+
+1. **Given** `--trace <path>` is passed, **When** the CLI makes any HTTP request, **Then** each request and response is appended to the file at `<path>` with method, URL, status code, and response body, and Authorization header values are fully redacted (replaced with `[REDACTED]`).
+2. **Given** the trace file path does not exist, **When** `--trace` is used, **Then** the file is created automatically.
+3. **Given** `--trace` is not passed, **When** a command runs, **Then** no trace file is created and behavior is identical to current.
+4. **Given** a trace file is written, **When** it is inspected, **Then** no credential values, tokens, or PAT strings appear anywhere in the file.
+
+---
+
+### Edge Cases
+
+- What happens when the `--trace` target path is not writable? → Command prints a warning to stderr and continues without tracing (non-fatal).
+- What happens when the configured org does not exist in Azure DevOps? → `auth diagnose` reports the HTTP status code and response body from the connectivity test.
+- What if the user has multiple orgs configured? → `auth diagnose` operates on the org resolved by the normal context resolution rules; it diagnoses one org at a time.
+- What if the OAuth token is expired? → Diagnose attempts the connectivity test and surfaces the resulting API error.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST provide an `azdo auth diagnose` subcommand that prints the active auth type (PAT or OAuth), the credential source location, the configured org, and the result of a live Azure DevOps connectivity test.
+- **FR-002**: The connectivity test in `auth diagnose` MUST include the exact API error message returned by Azure DevOps when authentication fails, not a generic CLI-level message.
+- **FR-003**: The CLI MUST accept a global `--trace <filepath>` flag on any command that writes HTTP request and response details to the specified file.
+- **FR-004**: The trace log MUST redact all credential values (PAT strings, Bearer tokens, Basic auth header values) replacing them with `[REDACTED]` before writing to disk.
+- **FR-005**: The `auth diagnose` command MUST exit with a non-zero code when the connectivity test fails.
+- **FR-006**: The `--trace` flag failure to open the output file MUST be non-fatal — the command continues and prints a warning to stderr.
+- **FR-007**: The `auth diagnose` output MUST be human-readable plain text by default; a `--json` flag MAY be supported for machine-readable output.
+
+### Key Entities
+
+- **Auth Diagnostic Report**: The structured set of fields printed by `auth diagnose` — auth type, credential source, org, project (if set), connectivity status, and error detail.
+- **Trace Entry**: One HTTP exchange (request + response) written to the trace log — method, URL, request headers (redacted), request body, status code, response headers, response body.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A developer encountering an auth failure can identify the root cause (wrong PAT scope, wrong org, expired token, missing credentials) without leaving the terminal — no external tools required.
+- **SC-002**: The `auth diagnose` command completes and prints its report in under 5 seconds on a normal network connection.
+- **SC-003**: The trace log never contains a credential value — verified by automated test scanning the output for known token patterns.
+- **SC-004**: Reduce the "auth failed, no idea why" class of support questions by providing a self-service diagnostic path that surfaces actionable error details.
+
+## Assumptions
+
+- The existing `azdo auth` command group is the natural home for `azdo auth diagnose`; a flat `azdo diagnose` alias is out of scope.
+- "Credential source" means the named store from which the token was retrieved (e.g. system keychain name, environment variable name, config file path) — not the token value itself.
+- The connectivity test calls the same Azure DevOps endpoint that normal commands use, using the resolved credentials.
+- The `--trace` flag is global (registered on the root command) and applies to every HTTP call the process makes during that invocation.
+- Token redaction covers: `Authorization` header values, any query parameter named `token` or `pat`, and any JSON body field named `token`, `accessToken`, or `pat`.
+- The trace log appends to an existing file so multiple invocations in a debugging session accumulate in one file.
+
+## Clarifications
+
+### Session 2026-06-15
+
+- Q: Should `auth diagnose` follow normal context resolution (env vars → config → flags)? → A: Yes, same as all other commands; `--org` and `--project` overrides work if provided.
+- Q: Should the trace log append or overwrite? → A: Append, so multiple invocations in a debugging session accumulate in one file.

--- a/specs/030-auth-diagnostics/tasks.md
+++ b/specs/030-auth-diagnostics/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Auth Diagnostics
+
+**Input**: Design documents from `/specs/030-auth-diagnostics/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: New type and service files needed by both user stories
+
+- [ ] T001 Create `src/types/auth-diagnostics.ts` with `AuthDiagnosticReport` and `TraceEntry` interfaces per data-model.md
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared infrastructure required by both user stories before implementation begins
+
+- [ ] T002 Create `src/services/trace-writer.ts` with `TraceWriter` class (append to file, `0o600` mode on Unix), module-level singleton `initTraceWriter(path)` / `getActiveTraceWriter()`, and `redactHeaders()`/`redactBody()` redaction helpers per contracts/trace-flag-cli.md
+- [ ] T003 Add `fetchRaw(url, init)` helper to `src/services/azdo-client.ts` that calls native `fetch` and returns `{ status, body }` without throwing — used by diagnose connectivity test to surface raw ADO error messages
+
+**Checkpoint**: TraceWriter singleton and raw-fetch helper ready — user story work can now begin
+
+---
+
+## Phase 3: User Story 1 — Auth Diagnose Command (Priority: P1) 🎯 MVP
+
+**Goal**: `azdo auth diagnose` prints auth type, credential source, org, and scope-aware connectivity result with exact API error on failure
+
+**Independent Test**: `azdo auth diagnose --org <org>` with a valid PAT prints "Connectivity: OK"; with an invalid PAT prints "Connectivity: FAILED" and the exact ADO error message; with no credentials prints "Auth type: none"
+
+- [ ] T004 [US1] Create `src/services/auth-diagnostics.ts` with `runConnectivityTest(org, cred)` that calls `GET https://dev.azure.com/{org}/_apis/projects?api-version=7.1&$top=1` via `fetchRaw()` and returns `{ status: 'ok' | 'failed', error: string | null }` per research.md §2
+- [ ] T005 [US1] Add `diagnoseAuth(org, project?)` function to `src/services/auth-diagnostics.ts` that calls `resolveAuthCredential(org)`, maps `{ kind, source }` to `AuthDiagnosticReport` fields, calls `runConnectivityTest()`, and returns the complete `AuthDiagnosticReport`
+- [ ] T006 [US1] Add `formatDiagnosticReport(report, json)` to `src/services/auth-diagnostics.ts` that renders human-readable output (per contracts/auth-diagnose-cli.md §Output) or JSON (`--json` flag)
+- [ ] T007 [US1] Add `createAuthDiagnoseCommand()` to `src/commands/auth.ts` that accepts `--org`, `--project`, `--json` options, calls `diagnoseAuth()`, writes formatted output to stdout, exits non-zero when `connectivityStatus === 'failed'`
+- [ ] T008 [US1] Register `createAuthDiagnoseCommand()` as a subcommand of `createAuthCommand()` in `src/commands/auth.ts`
+- [ ] T009 [US1] Add unit tests in `tests/unit/auth-diagnostics.test.ts` covering: OK connectivity, FAILED connectivity with error text, no-credentials path, JSON output format, and `formatDiagnosticReport` human-readable layout
+
+---
+
+## Phase 4: User Story 2 — HTTP Request/Response Trace Log (Priority: P2)
+
+**Goal**: `--trace <filepath>` global flag appends redacted HTTP entries to a file for any `azdo` command
+
+**Independent Test**: `azdo --trace /tmp/t.log get-item 1` creates the log file; inspecting it shows request/response entries with `[REDACTED]` in place of the Authorization header value; running a second time appends rather than overwrites
+
+- [ ] T010 [US2] Modify `fetchWithErrors(url, init)` in `src/services/azdo-client.ts` to call `getActiveTraceWriter()` and, when non-null, append a `TraceEntry` (with redacted headers/body) after every response — both successful and error responses
+- [ ] T011 [US2] Register `--trace <filepath>` option on the root `program` command in `src/index.ts`; after `program.parseOptions()` / before `program.parseAsync()`, call `initTraceWriter(opts.trace)` when the flag is present
+- [ ] T012 [US2] Add unit tests in `tests/unit/trace-writer.test.ts` covering: file creation with `0o600` mode (skipped on Windows), append behaviour across multiple writes, `[REDACTED]` substitution in Authorization header, redaction of `token`/`accessToken`/`pat` JSON body fields, non-writable path is non-fatal (warning to stderr)
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, README update, final validation
+
+- [ ] T013 [P] Update `README.md` to document `azdo auth diagnose` usage and the global `--trace` flag with examples from quickstart.md
+- [ ] T014 [P] Update `docs/commands.md` (if present) with `azdo auth diagnose` command reference entry
+- [ ] T015 Run full build (`npm run build`) and test suite (`npm test`) and fix any TypeScript errors or test failures
+
+---
+
+## Dependencies
+
+```
+T001 (types)
+  └─ T002 (TraceWriter) ──────────────────────── T010, T011, T012
+  └─ T003 (fetchRaw) ──── T004, T005 ─── T006 ─── T007 ─── T008, T009
+```
+
+US1 (T004–T009) and US2 (T010–T012) can proceed in parallel after Phase 2 completes.
+
+## Implementation Strategy
+
+**MVP** (Phase 1–3 only): Ship `azdo auth diagnose` first — solves the user's immediate debugging problem with no risk to existing commands.
+
+**Full delivery** (Phase 4): Add `--trace` — invasive change to `fetchWithErrors` and `src/index.ts`; best done after US1 is proven stable.

--- a/specs/030-auth-diagnostics/tasks.md
+++ b/specs/030-auth-diagnostics/tasks.md
@@ -14,7 +14,7 @@
 
 **Purpose**: New type and service files needed by both user stories
 
-- [ ] T001 Create `src/types/auth-diagnostics.ts` with `AuthDiagnosticReport` and `TraceEntry` interfaces per data-model.md
+- [X] T001 Create `src/types/auth-diagnostics.ts` with `AuthDiagnosticReport` and `TraceEntry` interfaces per data-model.md
 
 ---
 
@@ -22,8 +22,8 @@
 
 **Purpose**: Shared infrastructure required by both user stories before implementation begins
 
-- [ ] T002 Create `src/services/trace-writer.ts` with `TraceWriter` class (append to file, `0o600` mode on Unix), module-level singleton `initTraceWriter(path)` / `getActiveTraceWriter()`, and `redactHeaders()`/`redactBody()` redaction helpers per contracts/trace-flag-cli.md
-- [ ] T003 Add `fetchRaw(url, init)` helper to `src/services/azdo-client.ts` that calls native `fetch` and returns `{ status, body }` without throwing — used by diagnose connectivity test to surface raw ADO error messages
+- [X] T002 Create `src/services/trace-writer.ts` with `TraceWriter` class (append to file, `0o600` mode on Unix), module-level singleton `initTraceWriter(path)` / `getActiveTraceWriter()`, and `redactHeaders()`/`redactBody()` redaction helpers per contracts/trace-flag-cli.md
+- [X] T003 Add `fetchRaw(url, init)` helper to `src/services/azdo-client.ts` that calls native `fetch` and returns `{ status, body }` without throwing — used by diagnose connectivity test to surface raw ADO error messages
 
 **Checkpoint**: TraceWriter singleton and raw-fetch helper ready — user story work can now begin
 
@@ -35,12 +35,12 @@
 
 **Independent Test**: `azdo auth diagnose --org <org>` with a valid PAT prints "Connectivity: OK"; with an invalid PAT prints "Connectivity: FAILED" and the exact ADO error message; with no credentials prints "Auth type: none"
 
-- [ ] T004 [US1] Create `src/services/auth-diagnostics.ts` with `runConnectivityTest(org, cred)` that calls `GET https://dev.azure.com/{org}/_apis/projects?api-version=7.1&$top=1` via `fetchRaw()` and returns `{ status: 'ok' | 'failed', error: string | null }` per research.md §2
-- [ ] T005 [US1] Add `diagnoseAuth(org, project?)` function to `src/services/auth-diagnostics.ts` that calls `resolveAuthCredential(org)`, maps `{ kind, source }` to `AuthDiagnosticReport` fields, calls `runConnectivityTest()`, and returns the complete `AuthDiagnosticReport`
-- [ ] T006 [US1] Add `formatDiagnosticReport(report, json)` to `src/services/auth-diagnostics.ts` that renders human-readable output (per contracts/auth-diagnose-cli.md §Output) or JSON (`--json` flag)
-- [ ] T007 [US1] Add `createAuthDiagnoseCommand()` to `src/commands/auth.ts` that accepts `--org`, `--project`, `--json` options, calls `diagnoseAuth()`, writes formatted output to stdout, exits non-zero when `connectivityStatus === 'failed'`
-- [ ] T008 [US1] Register `createAuthDiagnoseCommand()` as a subcommand of `createAuthCommand()` in `src/commands/auth.ts`
-- [ ] T009 [US1] Add unit tests in `tests/unit/auth-diagnostics.test.ts` covering: OK connectivity, FAILED connectivity with error text, no-credentials path, JSON output format, and `formatDiagnosticReport` human-readable layout
+- [X] T004 [US1] Create `src/services/auth-diagnostics.ts` with `runConnectivityTest(org, cred)` that calls `GET https://dev.azure.com/{org}/_apis/projects?api-version=7.1&$top=1` via `fetchRaw()` and returns `{ status: 'ok' | 'failed', error: string | null }` per research.md §2
+- [X] T005 [US1] Add `diagnoseAuth(org, project?)` function to `src/services/auth-diagnostics.ts` that calls `resolveAuthCredential(org)`, maps `{ kind, source }` to `AuthDiagnosticReport` fields, calls `runConnectivityTest()`, and returns the complete `AuthDiagnosticReport`
+- [X] T006 [US1] Add `formatDiagnosticReport(report, json)` to `src/services/auth-diagnostics.ts` that renders human-readable output (per contracts/auth-diagnose-cli.md §Output) or JSON (`--json` flag)
+- [X] T007 [US1] Add `createAuthDiagnoseCommand()` to `src/commands/auth.ts` that accepts `--org`, `--project`, `--json` options, calls `diagnoseAuth()`, writes formatted output to stdout, exits non-zero when `connectivityStatus === 'failed'`
+- [X] T008 [US1] Register `createAuthDiagnoseCommand()` as a subcommand of `createAuthCommand()` in `src/commands/auth.ts`
+- [X] T009 [US1] Add unit tests in `tests/unit/auth-diagnostics.test.ts` covering: OK connectivity, FAILED connectivity with error text, no-credentials path, JSON output format, and `formatDiagnosticReport` human-readable layout
 
 ---
 
@@ -50,9 +50,9 @@
 
 **Independent Test**: `azdo --trace /tmp/t.log get-item 1` creates the log file; inspecting it shows request/response entries with `[REDACTED]` in place of the Authorization header value; running a second time appends rather than overwrites
 
-- [ ] T010 [US2] Modify `fetchWithErrors(url, init)` in `src/services/azdo-client.ts` to call `getActiveTraceWriter()` and, when non-null, append a `TraceEntry` (with redacted headers/body) after every response — both successful and error responses
-- [ ] T011 [US2] Register `--trace <filepath>` option on the root `program` command in `src/index.ts`; after `program.parseOptions()` / before `program.parseAsync()`, call `initTraceWriter(opts.trace)` when the flag is present
-- [ ] T012 [US2] Add unit tests in `tests/unit/trace-writer.test.ts` covering: file creation with `0o600` mode (skipped on Windows), append behaviour across multiple writes, `[REDACTED]` substitution in Authorization header, redaction of `token`/`accessToken`/`pat` JSON body fields, non-writable path is non-fatal (warning to stderr)
+- [X] T010 [US2] Modify `fetchWithErrors(url, init)` in `src/services/azdo-client.ts` to call `getActiveTraceWriter()` and, when non-null, append a `TraceEntry` (with redacted headers/body) after every response — both successful and error responses
+- [X] T011 [US2] Register `--trace <filepath>` option on the root `program` command in `src/index.ts`; after `program.parseOptions()` / before `program.parseAsync()`, call `initTraceWriter(opts.trace)` when the flag is present
+- [X] T012 [US2] Add unit tests in `tests/unit/trace-writer.test.ts` covering: file creation with `0o600` mode (skipped on Windows), append behaviour across multiple writes, `[REDACTED]` substitution in Authorization header, redaction of `token`/`accessToken`/`pat` JSON body fields, non-writable path is non-fatal (warning to stderr)
 
 ---
 
@@ -60,9 +60,9 @@
 
 **Purpose**: Documentation, README update, final validation
 
-- [ ] T013 [P] Update `README.md` to document `azdo auth diagnose` usage and the global `--trace` flag with examples from quickstart.md
-- [ ] T014 [P] Update `docs/commands.md` (if present) with `azdo auth diagnose` command reference entry
-- [ ] T015 Run full build (`npm run build`) and test suite (`npm test`) and fix any TypeScript errors or test failures
+- [X] T013 [P] Update `README.md` to document `azdo auth diagnose` usage and the global `--trace` flag with examples from quickstart.md
+- [X] T014 [P] Update `docs/commands.md` (if present) with `azdo auth diagnose` command reference entry
+- [X] T015 Run full build (`npm run build`) and test suite (`npm test`) and fix any TypeScript errors or test failures
 
 ---
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -7,6 +7,7 @@ import {
   loginWithOAuth,
   logout as logoutService,
   status as statusService,
+  resolveAuthCredential,
   type OAuthLoginOptions,
 } from '../services/auth.js';
 import {
@@ -21,6 +22,7 @@ import { resolveOrg, formatResolutionError } from '../services/org-resolver.js';
 import { openUrl } from '../services/browser-open.js';
 import { appendAuthAuditEvent, readAuditEvents } from '../services/audit-log.js';
 import { AZDO_RESOURCE_ID, defaultScopes, firstPartyShippedScopes } from '../services/oauth-config.js';
+import { diagnoseAuth, formatDiagnosticReport } from '../services/auth-diagnostics.js';
 
 type RootOptions = {
   org?: string;
@@ -490,6 +492,29 @@ Note: \`azdo auth\` (no subcommand) preserves the legacy PAT-prompt entry point;
   logoutCmd.action(async (options: { all?: boolean }) => {
     const globals = logoutCmd.optsWithGlobals() as GlobalsWithOrg;
     await handleLogout(options, globals.org);
+  });
+
+  const diagnoseCmd = command
+    .command('diagnose')
+    .description('Show auth type, credential source, org, and live connectivity test result')
+    .option('--org <name>', 'Azure DevOps organization (overrides context resolution)')
+    .option('--project <name>', 'Azure DevOps project (optional context)')
+    .option('--json', 'emit JSON instead of human-readable text', false);
+  diagnoseCmd.action(async (options: { org?: string; project?: string; json?: boolean }) => {
+    const globals = diagnoseCmd.optsWithGlobals() as GlobalsWithOrg;
+    const orgName = options.org ?? globals.org;
+    const resolved = resolveOrg({ org: orgName });
+    if (!resolved) {
+      process.stderr.write(`${formatResolutionError()}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    const report = await diagnoseAuth(resolved.org, options.project ?? null, resolveAuthCredential);
+    const output = formatDiagnosticReport(report, options.json ?? false);
+    process.stdout.write(`${output}\n`);
+    if (report.connectivityStatus === 'failed') {
+      process.exitCode = 1;
+    }
   });
 
   return command;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { createCommentsCommand } from "./commands/comments.js";
 import { createDownloadAttachmentCommand } from "./commands/download-attachment.js";
 import { createRelationsCommand } from "./commands/relations.js";
 import { getUpdateNotice } from "./services/update-check.js";
+import { initTraceWriter } from "./services/trace-writer.js";
 
 // Standard CLI behaviour for `azdo … | head`: when the downstream reader
 // closes the pipe early, swallow EPIPE and exit cleanly instead of dumping
@@ -35,6 +36,7 @@ const program = new Command();
 program.name("azdo").description("Azure DevOps CLI tool").version(version, "-v, --version");
 
 program.option("--no-update-check", "Skip the check for a newer published version");
+program.option("--trace <filepath>", "Append redacted HTTP request/response trace to a file (owner-read-only permissions)");
 
 program.addCommand(createGetItemCommand());
 program.addCommand(createAuthCommand());
@@ -54,6 +56,13 @@ program.addCommand(createDownloadAttachmentCommand());
 program.addCommand(createRelationsCommand());
 
 program.showHelpAfterError();
+
+program.hook("preAction", () => {
+  const { trace } = program.opts() as { trace?: string };
+  if (trace) {
+    initTraceWriter(trace);
+  }
+});
 
 // After a command finishes, print a best-effort update notice on stderr.
 // The hook only fires for action commands, so -v/--version and help paths

--- a/src/services/auth-diagnostics.ts
+++ b/src/services/auth-diagnostics.ts
@@ -53,7 +53,7 @@ export async function diagnoseAuth(
     : 'credential-store';
 
   return {
-    authType: cred.kind,
+    authType: cred.kind ?? 'pat',
     credentialSource: sourceLabel,
     org,
     project,

--- a/src/services/auth-diagnostics.ts
+++ b/src/services/auth-diagnostics.ts
@@ -1,0 +1,90 @@
+import type { AuthCredential } from '../types/work-item.js';
+import type { AuthDiagnosticReport } from '../types/auth-diagnostics.js';
+import { authHeaders, fetchRaw } from './azdo-client.js';
+
+interface ConnectivityResult {
+  status: 'ok' | 'failed';
+  error: string | null;
+}
+
+export async function runConnectivityTest(org: string, cred: AuthCredential): Promise<ConnectivityResult> {
+  const url = `https://dev.azure.com/${encodeURIComponent(org)}/_apis/projects?api-version=7.1&$top=1`;
+  let result: { status: number; body: string };
+  try {
+    result = await fetchRaw(url, { headers: authHeaders(cred) });
+  } catch (err) {
+    return { status: 'failed', error: err instanceof Error ? err.message : String(err) };
+  }
+  if (result.status >= 200 && result.status < 300) {
+    return { status: 'ok', error: null };
+  }
+  let error = `HTTP ${result.status}`;
+  try {
+    const parsed = JSON.parse(result.body) as { message?: unknown };
+    if (typeof parsed.message === 'string' && parsed.message.trim() !== '') {
+      error = parsed.message.trim();
+    }
+  } catch { /* use fallback */ }
+  return { status: 'failed', error };
+}
+
+export async function diagnoseAuth(
+  org: string,
+  project: string | null,
+  resolveCredential: (o: string) => Promise<AuthCredential | null>,
+): Promise<AuthDiagnosticReport> {
+  const cred = await resolveCredential(org);
+
+  if (cred === null) {
+    return {
+      authType: 'none',
+      credentialSource: null,
+      org,
+      project,
+      connectivityStatus: 'no-credentials',
+      connectivityError: null,
+    };
+  }
+
+  const connectivity = await runConnectivityTest(org, cred);
+
+  const sourceLabel = cred.source === 'env'
+    ? `env:${process.env.AZDO_PAT ? 'AZDO_PAT' : 'dotenv'}`
+    : 'credential-store';
+
+  return {
+    authType: cred.kind,
+    credentialSource: sourceLabel,
+    org,
+    project,
+    connectivityStatus: connectivity.status,
+    connectivityError: connectivity.error,
+  };
+}
+
+export function formatDiagnosticReport(report: AuthDiagnosticReport, json: boolean): string {
+  if (json) {
+    return JSON.stringify(report, null, 2);
+  }
+
+  const connectivityLine =
+    report.connectivityStatus === 'ok'
+      ? 'OK'
+      : report.connectivityStatus === 'no-credentials'
+        ? 'no credentials found'
+        : 'FAILED';
+
+  const lines = [
+    `Auth type:    ${report.authType}`,
+    `Source:       ${report.credentialSource ?? '(none)'}`,
+    `Org:          ${report.org}`,
+    `Project:      ${report.project ?? '(not set)'}`,
+    `Connectivity: ${connectivityLine}`,
+  ];
+
+  if (report.connectivityStatus === 'failed' && report.connectivityError !== null) {
+    lines.push(`Error:        ${report.connectivityError}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/services/auth-diagnostics.ts
+++ b/src/services/auth-diagnostics.ts
@@ -48,9 +48,8 @@ export async function diagnoseAuth(
 
   const connectivity = await runConnectivityTest(org, cred);
 
-  const sourceLabel = cred.source === 'env'
-    ? `env:${process.env.AZDO_PAT ? 'AZDO_PAT' : 'dotenv'}`
-    : 'credential-store';
+  const envVarName = process.env.AZDO_PAT ? 'AZDO_PAT' : 'dotenv';
+  const sourceLabel = cred.source === 'env' ? `env:${envVarName}` : 'credential-store';
 
   return {
     authType: cred.kind ?? 'pat',
@@ -67,12 +66,14 @@ export function formatDiagnosticReport(report: AuthDiagnosticReport, json: boole
     return JSON.stringify(report, null, 2);
   }
 
-  const connectivityLine =
-    report.connectivityStatus === 'ok'
-      ? 'OK'
-      : report.connectivityStatus === 'no-credentials'
-        ? 'no credentials found'
-        : 'FAILED';
+  let connectivityLine: string;
+  if (report.connectivityStatus === 'ok') {
+    connectivityLine = 'OK';
+  } else if (report.connectivityStatus === 'no-credentials') {
+    connectivityLine = 'no credentials found';
+  } else {
+    connectivityLine = 'FAILED';
+  }
 
   const lines = [
     `Auth type:    ${report.authType}`,

--- a/src/services/azdo-client.ts
+++ b/src/services/azdo-client.ts
@@ -42,7 +42,7 @@ export async function fetchRaw(url: string, init: RequestInit): Promise<{ status
   try {
     response = await fetch(url, init);
   } catch (err) {
-    throw new Error(`NETWORK_ERROR: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`NETWORK_ERROR: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   }
   const body = await response.text();
   return { status: response.status, body };
@@ -54,7 +54,7 @@ export async function fetchWithErrors(url: string, init: RequestInit): Promise<R
   try {
     response = await fetch(url, init);
   } catch (err) {
-    throw new Error('NETWORK_ERROR');
+    throw new Error('NETWORK_ERROR', { cause: err });
   }
 
   if (writer) {

--- a/src/services/azdo-client.ts
+++ b/src/services/azdo-client.ts
@@ -10,6 +10,8 @@ import type {
   WorkItemCommentsResult,
   WriteResult,
 } from '../types/work-item.js';
+import { getActiveTraceWriter, redactHeaders, redactUrl, redactBody } from './trace-writer.js';
+import type { TraceEntry } from '../types/auth-diagnostics.js';
 
 const DEFAULT_FIELDS: readonly string[] = [
   'System.Title',
@@ -35,12 +37,46 @@ export function authHeaders(credentialOrPat: AuthCredential | string): Record<st
   return { Authorization: `Basic ${token}` };
 }
 
-export async function fetchWithErrors(url: string, init: RequestInit): Promise<Response> {
+export async function fetchRaw(url: string, init: RequestInit): Promise<{ status: number; body: string }> {
   let response: Response;
   try {
     response = await fetch(url, init);
-  } catch {
+  } catch (err) {
+    throw new Error(`NETWORK_ERROR: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const body = await response.text();
+  return { status: response.status, body };
+}
+
+export async function fetchWithErrors(url: string, init: RequestInit): Promise<Response> {
+  const writer = getActiveTraceWriter();
+  let response: Response;
+  try {
+    response = await fetch(url, init);
+  } catch (err) {
     throw new Error('NETWORK_ERROR');
+  }
+
+  if (writer) {
+    const reqHeaders = redactHeaders((init.headers ?? {}) as Record<string, string>);
+    const reqBody = typeof init.body === 'string' ? redactBody(init.body) : null;
+    let responseBody = '';
+    // Clone the response so we can read the body for tracing without consuming it.
+    const clone = response.clone();
+    try { responseBody = await clone.text(); } catch { /* ignore */ }
+    const respHeaders: Record<string, string> = {};
+    response.headers.forEach((v, k) => { respHeaders[k] = v; });
+    const entry: TraceEntry = {
+      timestamp: new Date().toISOString(),
+      method: (init.method ?? 'GET').toUpperCase(),
+      url: redactUrl(url),
+      requestHeaders: reqHeaders,
+      requestBody: reqBody ?? null,
+      responseStatus: response.status,
+      responseHeaders: respHeaders,
+      responseBody,
+    };
+    writer.append(entry);
   }
 
   if (response.status === 401) throw new Error('AUTH_FAILED');

--- a/src/services/trace-writer.ts
+++ b/src/services/trace-writer.ts
@@ -1,0 +1,82 @@
+import { openSync, writeSync, closeSync } from 'node:fs';
+import { platform } from 'node:os';
+import type { TraceEntry } from '../types/auth-diagnostics.js';
+
+const REDACTED = '[REDACTED]';
+const SENSITIVE_HEADER = /^(authorization|x-.*token)$/i;
+const SENSITIVE_QUERY_PARAM = /^(token|pat)$/i;
+const SENSITIVE_BODY_FIELD = /^(token|accessToken|pat)$/;
+
+export function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[key] = SENSITIVE_HEADER.test(key) ? REDACTED : value;
+  }
+  return out;
+}
+
+export function redactUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    for (const [key] of u.searchParams.entries()) {
+      if (SENSITIVE_QUERY_PARAM.test(key)) {
+        u.searchParams.set(key, REDACTED);
+      }
+    }
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
+export function redactBody(body: string | null): string | null {
+  if (body === null) return null;
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    let changed = false;
+    const redacted: Record<string, unknown> = { ...parsed };
+    for (const key of Object.keys(parsed)) {
+      if (SENSITIVE_BODY_FIELD.test(key)) {
+        redacted[key] = REDACTED;
+        changed = true;
+      }
+    }
+    return changed ? JSON.stringify(redacted) : body;
+  } catch {
+    return body;
+  }
+}
+
+export class TraceWriter {
+  private readonly fd: number;
+
+  constructor(filepath: string) {
+    // 0o600 = owner read/write only (ignored on Windows but harmless)
+    const mode = platform() === 'win32' ? undefined : 0o600;
+    this.fd = openSync(filepath, 'a', mode);
+  }
+
+  append(entry: TraceEntry): void {
+    const line = JSON.stringify(entry) + '\n\n';
+    writeSync(this.fd, line);
+  }
+
+  close(): void {
+    closeSync(this.fd);
+  }
+}
+
+let activeWriter: TraceWriter | null = null;
+
+export function initTraceWriter(filepath: string): void {
+  try {
+    activeWriter = new TraceWriter(filepath);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Warning: could not open trace file "${filepath}": ${msg}\n`);
+  }
+}
+
+export function getActiveTraceWriter(): TraceWriter | null {
+  return activeWriter;
+}

--- a/src/types/auth-diagnostics.ts
+++ b/src/types/auth-diagnostics.ts
@@ -1,0 +1,19 @@
+export interface AuthDiagnosticReport {
+  authType: 'pat' | 'oauth' | 'none';
+  credentialSource: string | null;
+  org: string;
+  project: string | null;
+  connectivityStatus: 'ok' | 'failed' | 'no-credentials';
+  connectivityError: string | null;
+}
+
+export interface TraceEntry {
+  timestamp: string;
+  method: string;
+  url: string;
+  requestHeaders: Record<string, string>;
+  requestBody: string | null;
+  responseStatus: number;
+  responseHeaders: Record<string, string>;
+  responseBody: string;
+}

--- a/tests/unit/auth-diagnostics.test.ts
+++ b/tests/unit/auth-diagnostics.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+import { diagnoseAuth, formatDiagnosticReport, runConnectivityTest } from '../../src/services/auth-diagnostics.js';
+import type { AuthDiagnosticReport } from '../../src/types/auth-diagnostics.js';
+import type { AuthCredential } from '../../src/types/work-item.js';
+
+const { fetchRawMock } = vi.hoisted(() => ({ fetchRawMock: vi.fn() }));
+
+vi.mock('../../src/services/azdo-client.js', () => ({
+  authHeaders: vi.fn(() => ({ Authorization: 'Basic test' })),
+  fetchRaw: fetchRawMock,
+}));
+
+const mockPatCred: AuthCredential = { pat: 'tok', source: 'env', kind: 'pat' };
+const mockOAuthCred: AuthCredential = { pat: 'tok', source: 'credential-store', kind: 'oauth' };
+
+describe('runConnectivityTest', () => {
+  it('returns ok on 2xx', async () => {
+    fetchRawMock.mockResolvedValue({ status: 200, body: '{"value":[]}' });
+    const result = await runConnectivityTest('myorg', mockPatCred);
+    expect(result.status).toBe('ok');
+    expect(result.error).toBeNull();
+  });
+
+  it('returns failed with HTTP status on non-2xx without message', async () => {
+    fetchRawMock.mockResolvedValue({ status: 401, body: '{}' });
+    const result = await runConnectivityTest('myorg', mockPatCred);
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('HTTP 401');
+  });
+
+  it('extracts message from JSON body on error', async () => {
+    fetchRawMock.mockResolvedValue({ status: 403, body: JSON.stringify({ message: 'Access denied' }) });
+    const result = await runConnectivityTest('myorg', mockPatCred);
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('Access denied');
+  });
+
+  it('returns failed when fetchRaw throws', async () => {
+    fetchRawMock.mockRejectedValue(new Error('NETWORK_ERROR'));
+    const result = await runConnectivityTest('myorg', mockPatCred);
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('NETWORK_ERROR');
+  });
+});
+
+describe('diagnoseAuth', () => {
+  it('returns no-credentials when resolver returns null', async () => {
+    const report = await diagnoseAuth('myorg', null, async () => null);
+    expect(report.authType).toBe('none');
+    expect(report.connectivityStatus).toBe('no-credentials');
+    expect(report.credentialSource).toBeNull();
+  });
+
+  it('returns pat auth type with env source', async () => {
+    fetchRawMock.mockResolvedValue({ status: 200, body: '{"value":[]}' });
+    process.env.AZDO_PAT = 'tok';
+    const report = await diagnoseAuth('myorg', 'proj', async () => mockPatCred);
+    expect(report.authType).toBe('pat');
+    expect(report.credentialSource).toContain('env');
+    expect(report.connectivityStatus).toBe('ok');
+    expect(report.org).toBe('myorg');
+    expect(report.project).toBe('proj');
+    delete process.env.AZDO_PAT;
+  });
+
+  it('returns oauth auth type with credential-store source', async () => {
+    fetchRawMock.mockResolvedValue({ status: 200, body: '{}' });
+    const report = await diagnoseAuth('myorg', null, async () => mockOAuthCred);
+    expect(report.authType).toBe('oauth');
+    expect(report.credentialSource).toBe('credential-store');
+  });
+});
+
+describe('formatDiagnosticReport', () => {
+  const okReport: AuthDiagnosticReport = {
+    authType: 'pat',
+    credentialSource: 'env:AZDO_PAT',
+    org: 'myorg',
+    project: 'myproj',
+    connectivityStatus: 'ok',
+    connectivityError: null,
+  };
+
+  it('formats human-readable report', () => {
+    const text = formatDiagnosticReport(okReport, false);
+    expect(text).toContain('Auth type:');
+    expect(text).toContain('pat');
+    expect(text).toContain('myorg');
+    expect(text).toContain('myproj');
+    expect(text).toContain('OK');
+    expect(text).not.toContain('Error:');
+  });
+
+  it('formats JSON report', () => {
+    const text = formatDiagnosticReport(okReport, true);
+    const parsed = JSON.parse(text) as AuthDiagnosticReport;
+    expect(parsed.authType).toBe('pat');
+    expect(parsed.org).toBe('myorg');
+  });
+
+  it('includes Error line on failed connectivity', () => {
+    const failReport: AuthDiagnosticReport = {
+      ...okReport,
+      connectivityStatus: 'failed',
+      connectivityError: 'Access denied',
+    };
+    const text = formatDiagnosticReport(failReport, false);
+    expect(text).toContain('FAILED');
+    expect(text).toContain('Error:');
+    expect(text).toContain('Access denied');
+  });
+
+  it('shows (none) for null source', () => {
+    const noCredReport: AuthDiagnosticReport = {
+      ...okReport,
+      authType: 'none',
+      credentialSource: null,
+      connectivityStatus: 'no-credentials',
+    };
+    const text = formatDiagnosticReport(noCredReport, false);
+    expect(text).toContain('(none)');
+    expect(text).toContain('no credentials found');
+  });
+
+  it('shows (not set) for null project', () => {
+    const noProjectReport: AuthDiagnosticReport = { ...okReport, project: null };
+    const text = formatDiagnosticReport(noProjectReport, false);
+    expect(text).toContain('(not set)');
+  });
+});

--- a/tests/unit/trace-writer.test.ts
+++ b/tests/unit/trace-writer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { redactHeaders, redactUrl, redactBody, TraceWriter, initTraceWriter, getActiveTraceWriter } from '../../src/services/trace-writer.js';
+import { redactHeaders, redactUrl, redactBody, TraceWriter, initTraceWriter } from '../../src/services/trace-writer.js';
 import type { TraceEntry } from '../../src/types/auth-diagnostics.js';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/tests/unit/trace-writer.test.ts
+++ b/tests/unit/trace-writer.test.ts
@@ -111,7 +111,7 @@ describe('TraceWriter', () => {
     const content = readFileSync(tmpFile, 'utf-8');
     const lines = content.trim().split('\n').filter(Boolean);
     expect(lines).toHaveLength(1);
-    const parsed = JSON.parse(lines[0]!) as TraceEntry;
+    const parsed = JSON.parse(lines[0]!) as unknown as TraceEntry;
     expect(parsed.method).toBe('GET');
     expect(parsed.responseStatus).toBe(200);
   });

--- a/tests/unit/trace-writer.test.ts
+++ b/tests/unit/trace-writer.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { redactHeaders, redactUrl, redactBody, TraceWriter, initTraceWriter, getActiveTraceWriter } from '../../src/services/trace-writer.js';
+import type { TraceEntry } from '../../src/types/auth-diagnostics.js';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+
+describe('redactHeaders', () => {
+  it('redacts Authorization header', () => {
+    const result = redactHeaders({ Authorization: 'Basic abc123', 'Content-Type': 'application/json' });
+    expect(result['Authorization']).toBe('[REDACTED]');
+    expect(result['Content-Type']).toBe('application/json');
+  });
+
+  it('redacts x-*-token headers case-insensitively', () => {
+    const result = redactHeaders({ 'X-Auth-Token': 'secret', Accept: 'application/json' });
+    expect(result['X-Auth-Token']).toBe('[REDACTED]');
+    expect(result['Accept']).toBe('application/json');
+  });
+
+  it('passes through non-sensitive headers', () => {
+    const result = redactHeaders({ 'Content-Type': 'text/plain', Accept: '*/*' });
+    expect(result['Content-Type']).toBe('text/plain');
+    expect(result['Accept']).toBe('*/*');
+  });
+});
+
+describe('redactUrl', () => {
+  it('redacts token query param', () => {
+    const result = redactUrl('https://dev.azure.com/org/_apis/test?token=secret&api-version=7.1');
+    expect(result).not.toContain('secret');
+    expect(result).toContain('api-version=7.1');
+    // URL.searchParams.set() percent-encodes brackets, so check decoded form
+    expect(decodeURIComponent(result)).toContain('[REDACTED]');
+  });
+
+  it('redacts pat query param', () => {
+    const result = redactUrl('https://dev.azure.com/org/_apis/test?pat=abc123');
+    expect(result).not.toContain('abc123');
+  });
+
+  it('passes through non-sensitive query params', () => {
+    const result = redactUrl('https://dev.azure.com/org/_apis/projects?api-version=7.1&$top=1');
+    expect(result).toBe('https://dev.azure.com/org/_apis/projects?api-version=7.1&$top=1');
+  });
+
+  it('returns original url if not parseable', () => {
+    const result = redactUrl('not-a-url');
+    expect(result).toBe('not-a-url');
+  });
+});
+
+describe('redactBody', () => {
+  it('returns null for null input', () => {
+    expect(redactBody(null)).toBeNull();
+  });
+
+  it('redacts token field in JSON body', () => {
+    const body = JSON.stringify({ token: 'secret', name: 'test' });
+    const result = redactBody(body);
+    expect(result).not.toContain('secret');
+    expect(result).toContain('name');
+  });
+
+  it('redacts accessToken field', () => {
+    const body = JSON.stringify({ accessToken: 'tok123', scope: 'vso.work' });
+    const result = redactBody(body);
+    expect(result).not.toContain('tok123');
+    expect(result).toContain('scope');
+  });
+
+  it('passes through non-JSON body unchanged', () => {
+    const body = 'plain text body';
+    expect(redactBody(body)).toBe(body);
+  });
+
+  it('passes through JSON without sensitive fields unchanged', () => {
+    const body = JSON.stringify({ name: 'value', count: 3 });
+    expect(redactBody(body)).toBe(body);
+  });
+});
+
+describe('TraceWriter', () => {
+  let tmpFile: string;
+
+  beforeEach(() => {
+    tmpFile = join(tmpdir(), `trace-test-${Date.now()}.ndjson`);
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpFile)) {
+      unlinkSync(tmpFile);
+    }
+  });
+
+  it('creates file and appends NDJSON entries', () => {
+    const writer = new TraceWriter(tmpFile);
+    const entry: TraceEntry = {
+      timestamp: '2024-01-01T00:00:00.000Z',
+      method: 'GET',
+      url: 'https://dev.azure.com/org/_apis/projects',
+      requestHeaders: { Accept: 'application/json' },
+      requestBody: null,
+      responseStatus: 200,
+      responseHeaders: { 'content-type': 'application/json' },
+      responseBody: '{"value":[]}',
+    };
+    writer.append(entry);
+    writer.close();
+
+    const content = readFileSync(tmpFile, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]!) as TraceEntry;
+    expect(parsed.method).toBe('GET');
+    expect(parsed.responseStatus).toBe(200);
+  });
+
+  it('appends multiple entries', () => {
+    const writer = new TraceWriter(tmpFile);
+    const entry: TraceEntry = {
+      timestamp: '2024-01-01T00:00:00.000Z',
+      method: 'POST',
+      url: 'https://dev.azure.com/org/_apis/test',
+      requestHeaders: {},
+      requestBody: '{"key":"value"}',
+      responseStatus: 201,
+      responseHeaders: {},
+      responseBody: '',
+    };
+    writer.append(entry);
+    writer.append({ ...entry, method: 'GET', responseStatus: 200 });
+    writer.close();
+
+    const content = readFileSync(tmpFile, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(2);
+  });
+});
+
+describe('initTraceWriter / getActiveTraceWriter', () => {
+  let tmpFile: string;
+
+  beforeEach(() => {
+    tmpFile = join(tmpdir(), `trace-init-test-${Date.now()}.ndjson`);
+    // Reset module-level state by re-importing (workaround: test via side effects)
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpFile)) {
+      unlinkSync(tmpFile);
+    }
+  });
+
+  it('warns to stderr on bad path (does not throw)', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    initTraceWriter('/no/such/directory/trace.log');
+    stderrSpy.mockRestore();
+    // no exception thrown is the pass condition
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `azdo auth diagnose` — scope-aware connectivity test (auth type, credential source, org, exact ADO error on failure)
- Adds global `--trace <filepath>` flag — appends redacted HTTP request/response log to a file for any command

Closes #68

## Test plan

- [ ] `azdo auth diagnose --org <org>` with valid PAT → prints "Connectivity: OK"
- [ ] `azdo auth diagnose --org <org>` with invalid/scoped-wrong PAT → prints "Connectivity: FAILED" + exact ADO error
- [ ] `azdo auth diagnose --org <org>` with no credentials → prints "Auth type: none"
- [ ] `azdo auth diagnose --json` → valid JSON output
- [ ] `azdo --trace /tmp/t.log get-item 1` → log file created with `[REDACTED]` Authorization header
- [ ] Running twice with `--trace` → entries appended (not overwritten)
- [ ] `--trace` to non-writable path → warning to stderr, command continues
- [ ] All existing tests still pass (`npm test`)
- [ ] Build clean (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)